### PR TITLE
Repair unused, wrongly used vars etc

### DIFF
--- a/TermTk/TTkAbstract/abstractitemmodel.py
+++ b/TermTk/TTkAbstract/abstractitemmodel.py
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
+from TermTk.TTkCore.signal import pyTTkSignal
 
 class TTkAbstractItemModel():
     __slots__ = (

--- a/TermTk/TTkAbstract/abstractscrollarea.py
+++ b/TermTk/TTkAbstract/abstractscrollarea.py
@@ -22,10 +22,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from TermTk.TTkCore.constant import TTkConstant, TTkK
-from TermTk.TTkCore.log import TTkLog
+from TermTk.TTkCore.constant import TTkK
 from TermTk.TTkCore.cfg import *
-from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
+from TermTk.TTkCore.signal import pyTTkSlot
 from TermTk.TTkWidgets.widget import TTkWidget
 from TermTk.TTkWidgets.scrollbar import TTkScrollBar
 from TermTk.TTkLayouts.gridlayout import TTkGridLayout

--- a/TermTk/TTkAbstract/abstractscrollview.py
+++ b/TermTk/TTkAbstract/abstractscrollview.py
@@ -22,9 +22,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from TermTk.TTkCore.constant import TTkConstant, TTkK
+from TermTk.TTkCore.constant import TTkK
 from TermTk.TTkCore.cfg import *
-from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
 from TermTk.TTkWidgets.widget import TTkWidget
 

--- a/TermTk/TTkCore/TTkTerm/readinputlinux.py
+++ b/TermTk/TTkCore/TTkTerm/readinputlinux.py
@@ -29,7 +29,6 @@ except Exception as e:
     print(f'ERROR: {e}')
     exit(1)
 
-from TermTk.TTkCore.log import TTkLog
 
 class ReadInput():
     __slots__ = ('_readPipe')

--- a/TermTk/TTkCore/canvas.py
+++ b/TermTk/TTkCore/canvas.py
@@ -25,10 +25,10 @@
 from TermTk.TTkCore.TTkTerm.term import TTkTerm
 from TermTk.TTkCore.constant import TTkK
 from TermTk.TTkCore.log import TTkLog
-from TermTk.TTkCore.cfg import TTkCfg, TTkGlbl
+from TermTk.TTkCore.cfg import TTkCfg
 from TermTk.TTkCore.color import TTkColor
 from TermTk.TTkCore.string import TTkString
-from TermTk.TTkCore.helper import TTkHelper
+
 
 class TTkCanvas:
     ''' Init the Canvas object

--- a/TermTk/TTkCore/color.py
+++ b/TermTk/TTkCore/color.py
@@ -22,8 +22,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from TermTk.TTkCore.log import TTkLog
-from TermTk.TTkCore.cfg import TTkCfg
 from TermTk.TTkCore.constant import TTkK
 from TermTk.TTkCore.helper import TTkHelper
 

--- a/TermTk/TTkCore/color.py
+++ b/TermTk/TTkCore/color.py
@@ -82,7 +82,7 @@ class _TTkColor:
             r,g,b = self.fgToRGB()
         else:
             r,g,b = self.bgToRGB()
-        return "#{:06x}".format(r<<16|g<<8|b)
+        return f"#{r<<16|g<<8|b:06x}"
 
     def fgToRGB(self):
         if self._fg == "": return 0xff,0xff,0xff

--- a/TermTk/TTkCore/filebuffer.py
+++ b/TermTk/TTkCore/filebuffer.py
@@ -74,7 +74,7 @@ class TTkFileBuffer():
         self._width=0
         self._buffer = [None]*self._numW
         self._pages = [None]
-        self._fd = open(self._filename,'r')
+        self._fd = open(self._filename)
         threading.Thread(target=self.createIndex).start()
 
     def __del__(self):
@@ -148,7 +148,7 @@ class TTkFileBuffer():
                 offset+=len(chunk)
                 self.indexUpdated.emit(offset/fileSize)
                 # TTkLog.debug(f"{self._filename} {offset/fileSize} ...")
-        self._width = max([ (self._indexes[i+1]-self._indexes[i]) for i in range(len(self._indexes)-1) ])
+        self._width = max( (self._indexes[i+1]-self._indexes[i]) for i in range(len(self._indexes)-1) )
         self.indexUpdated.emit(1.0)
         self.indexed.emit()
         # TTkLog.debug(f"{self._filename} {offset/fileSize} END")
@@ -158,7 +158,7 @@ class TTkFileBuffer():
         id = 0
         rr = re.compile(regex, re.IGNORECASE if ignoreCase else 0)
         TTkLog.debug(f"Search RE: {regex}")
-        with open(self._filename,'r') as infile:
+        with open(self._filename) as infile:
             for line in infile:
                 ma = rr.search(line)
                 if ma:
@@ -168,7 +168,7 @@ class TTkFileBuffer():
 
     def search(self, txt):
         indexes = []
-        with open(self._filename,'r') as infile:
+        with open(self._filename) as infile:
             for line in infile:
                 if txt in line:
                     indexes.append(id)

--- a/TermTk/TTkCore/filebuffer.py
+++ b/TermTk/TTkCore/filebuffer.py
@@ -129,9 +129,9 @@ class TTkFileBuffer():
     def createIndex(self):
         # TTkLog.debug(f"Start Indexing {self._filename}")
         indexes = []
-        lines = 0
+        # lines = 0
         offset = 0
-        width = 0
+        # width = 0
         fileSize = os.stat(self._filename).st_size
         chunkSize = 0x1000000 # ~16M
         with open(self._filename,'rb') as infile:

--- a/TermTk/TTkCore/filebuffer.py
+++ b/TermTk/TTkCore/filebuffer.py
@@ -26,7 +26,7 @@ import os
 import re
 import threading
 from TermTk.TTkCore.log import TTkLog
-from TermTk.TTkCore.signal import pyTTkSignal, pyTTkSlot
+from TermTk.TTkCore.signal import pyTTkSignal
 
 '''
              w1   w3   w2   w5

--- a/TermTk/TTkCore/helper.py
+++ b/TermTk/TTkCore/helper.py
@@ -320,6 +320,7 @@ class TTkHelper:
             layout = layout.parent()
         return (wx, wy)
 
+    @staticmethod
     def nextFocus(widget):
         rootWidget = TTkHelper.rootOverlay(widget)
         if not rootWidget:
@@ -343,6 +344,7 @@ class TTkHelper:
             first.setFocus()
             first.update()
 
+    @staticmethod
     def prevFocus(widget):
         rootWidget = TTkHelper.rootOverlay(widget)
         if not rootWidget:

--- a/TermTk/TTkCore/helper.py
+++ b/TermTk/TTkCore/helper.py
@@ -59,11 +59,12 @@ class TTkHelper:
     def addShortcut(widget, letter):
         TTkHelper._shortcut.append(TTkHelper._Shortcut(letter, widget))
 
-    @staticmethod
-    def isParent(parent, widget):
-        if parent==widget: return True
-        if widget.parentWidget() is None: return False
-        return TTkHelper.isParent(parent,widget.parentWidget())
+    # redefined on line 306
+    # @staticmethod
+    # def isParent(parent, widget):
+    #     if parent==widget: return True
+    #     if widget.parentWidget() is None: return False
+    #     return TTkHelper.isParent(parent,widget.parentWidget())
 
     @staticmethod
     def execShortcut(letter, widget=None):

--- a/TermTk/TTkCore/helper.py
+++ b/TermTk/TTkCore/helper.py
@@ -24,7 +24,6 @@
 
 from TermTk.TTkCore.TTkTerm.colors import TTkTermColor
 from TermTk.TTkCore.TTkTerm.term import TTkTerm
-from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkCore.cfg import TTkCfg, TTkGlbl
 from TermTk.TTkCore.constant import TTkK
 

--- a/TermTk/TTkCore/signal.py
+++ b/TermTk/TTkCore/signal.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python3
 
 # MIT License

--- a/TermTk/TTkCore/string.py
+++ b/TermTk/TTkCore/string.py
@@ -71,6 +71,7 @@ class TTkString():
         self._hasTab = '\t' in self._text
         # raise AttributeError(f"{type(text)} not supported in TTkString")
 
+    @staticmethod
     def _parseAnsi(text, color = TTkColor.RST):
         pos = 0
         txtret = ""

--- a/TermTk/TTkCore/string.py
+++ b/TermTk/TTkCore/string.py
@@ -25,8 +25,6 @@
 import re
 
 from TermTk.TTkCore.constant import TTkK
-from TermTk.TTkCore.log import TTkLog
-from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
 from TermTk.TTkCore.color import TTkColor, _TTkColor
 
 class TTkString():

--- a/TermTk/TTkCore/string.py
+++ b/TermTk/TTkCore/string.py
@@ -281,7 +281,7 @@ class TTkString():
             ret._text   = self._text.replace(*args, **kwargs)
         else:
             start = 0
-            oldPos=0
+            # oldPos=0
             while pos := self._text.index(old, start) if old in self._text[start:] else None:
                 ret._colors += self._colors[start:pos+oldLen] + [self._colors[pos+oldLen-1]]*(newLen-oldLen)
                 start = pos+oldLen

--- a/TermTk/TTkCore/timer.py
+++ b/TermTk/TTkCore/timer.py
@@ -24,8 +24,6 @@
 
 import threading, time
 
-from TermTk.TTkCore.constant import TTkK
-from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
 
 

--- a/TermTk/TTkCore/ttk.py
+++ b/TermTk/TTkCore/ttk.py
@@ -192,7 +192,7 @@ class TTk(TTkWidget):
                 self.setGeometry(0,0,TTkGlbl.term_w,TTkGlbl.term_h)
                 TTkLog.info(f"Resize: w:{TTkGlbl.term_w}, h:{TTkGlbl.term_h}")
             elif evt is TTkK.QUIT_EVENT:
-                TTkLog.debug(f"Quit.")
+                TTkLog.debug("Quit.")
                 break
             else:
                 TTkLog.error(f"Unhandled Event {evt}")

--- a/TermTk/TTkCore/ttk.py
+++ b/TermTk/TTkCore/ttk.py
@@ -31,11 +31,9 @@ from TermTk.TTkCore.TTkTerm.input import TTkInput
 from TermTk.TTkCore.TTkTerm.term import TTkTerm
 from TermTk.TTkCore.constant import TTkK
 from TermTk.TTkCore.log import TTkLog
-from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
 from TermTk.TTkCore.cfg import *
 from TermTk.TTkCore.timer import *
 from TermTk.TTkTheme.theme import TTkTheme
-from TermTk.TTkLayouts.layout import TTkLayout
 from TermTk.TTkWidgets.widget import *
 
 class TTk(TTkWidget):

--- a/TermTk/TTkLayouts/boxlayout.py
+++ b/TermTk/TTkLayouts/boxlayout.py
@@ -26,7 +26,6 @@
 **Box Layout** [`Tutorial <https://ceccopierangiolieugenio.github.io/pyTermTk/tutorial/002-layout.html#simple-ttkvboxlayout>`_]
 '''
 
-from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkLayouts.gridlayout import TTkGridLayout
 
 class TTkHBoxLayout(TTkGridLayout):

--- a/TermTk/TTkLayouts/gridlayout.py
+++ b/TermTk/TTkLayouts/gridlayout.py
@@ -27,8 +27,7 @@
 '''
 
 from TermTk.TTkCore.constant import TTkK
-from TermTk.TTkCore.log import TTkLog
-from TermTk.TTkLayouts.layout import TTkLayout, TTkWidgetItem
+from TermTk.TTkLayouts.layout import TTkLayout
 
 class TTkGridLayout(TTkLayout):
     '''

--- a/TermTk/TTkLayouts/layout.py
+++ b/TermTk/TTkLayouts/layout.py
@@ -26,7 +26,6 @@
 **Layout** [`Tutorial <https://ceccopierangiolieugenio.github.io/pyTermTk/tutorial/002-layout.html#simple-ttklayout>`_]
 '''
 
-from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkCore.constant import TTkK
 
 class TTkLayoutItem:

--- a/TermTk/TTkTemplates/color.py
+++ b/TermTk/TTkTemplates/color.py
@@ -23,7 +23,6 @@
 # SOFTWARE.
 
 from TermTk.TTkCore.color import TTkColor
-from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
 
 class TColor():
     #__slots__ = ('_color')

--- a/TermTk/TTkTestWidgets/logviewer.py
+++ b/TermTk/TTkTestWidgets/logviewer.py
@@ -26,10 +26,7 @@ import os
 from TermTk.TTkCore.constant import TTkK
 from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkCore.color import TTkColor
-from TermTk.TTkWidgets.frame import TTkFrame
-from TermTk.TTkTemplates.color import TColor
-from TermTk.TTkTemplates.text  import TText
-from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
+from TermTk.TTkCore.signal import pyTTkSlot
 from TermTk.TTkAbstract.abstractscrollarea import TTkAbstractScrollArea
 from TermTk.TTkAbstract.abstractscrollview import TTkAbstractScrollView
 

--- a/TermTk/TTkTestWidgets/logviewer.py
+++ b/TermTk/TTkTestWidgets/logviewer.py
@@ -76,7 +76,7 @@ class _TTkLogViewer(TTkAbstractScrollView):
     def paintEvent(self):
         ox,oy = self.getViewOffsets()
         _,h = self.size()
-        offset = max(0,ox)
+        # offset = max(0,ox)
         for y, message in enumerate(self._messages[oy:]):
             self._canvas.drawText(pos=(0,y),text=message[ox:])
             c = TTkColor.RST

--- a/TermTk/TTkTestWidgets/logviewer.py
+++ b/TermTk/TTkTestWidgets/logviewer.py
@@ -49,7 +49,7 @@ class _TTkLogViewer(TTkAbstractScrollView):
         self.update()
 
     def viewFullAreaSize(self) -> (int, int):
-        w = max([ len(m) for m in self._messages])
+        w = max( len(m) for m in self._messages)
         h = len(self._messages)
         return w , h
 

--- a/TermTk/TTkTestWidgets/testwidgetsizes.py
+++ b/TermTk/TTkTestWidgets/testwidgetsizes.py
@@ -22,8 +22,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from TermTk.TTkCore.log import TTkLog
-from TermTk.TTkCore.color import TTkColor
 from TermTk.TTkWidgets.frame import *
 
 class TTkTestWidgetSizes(TTkFrame):

--- a/TermTk/TTkTheme/fileicon_nerd.py
+++ b/TermTk/TTkTheme/fileicon_nerd.py
@@ -30,7 +30,7 @@
 
 import re
 import os
-from TermTk.TTkCore.color import TTkColor
+
 
 class FileIcon():
     folderClose = ''

--- a/TermTk/TTkWidgets/Fancy/table.py
+++ b/TermTk/TTkWidgets/Fancy/table.py
@@ -22,13 +22,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from TermTk.TTkCore.cfg import TTkCfg
 from TermTk.TTkCore.constant import TTkK
-from TermTk.TTkCore.log import TTkLog
-from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
-from TermTk.TTkCore.color import TTkColor
 from TermTk.TTkWidgets.Fancy.tableview import TTkFancyTableView
-from TermTk.TTkLayouts.gridlayout import TTkGridLayout
 from TermTk.TTkAbstract.abstractscrollarea import TTkAbstractScrollArea
 
 class TTkFancyTable(TTkAbstractScrollArea):

--- a/TermTk/TTkWidgets/Fancy/tableview.py
+++ b/TermTk/TTkWidgets/Fancy/tableview.py
@@ -22,9 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from TermTk.TTkCore.cfg import TTkCfg
 from TermTk.TTkCore.constant import TTkK
-from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
 from TermTk.TTkCore.color import TTkColor
 from TermTk.TTkWidgets.widget import TTkWidget

--- a/TermTk/TTkWidgets/Fancy/tree.py
+++ b/TermTk/TTkWidgets/Fancy/tree.py
@@ -22,13 +22,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from TermTk.TTkCore.cfg import TTkCfg
 from TermTk.TTkCore.constant import TTkK
-from TermTk.TTkCore.log import TTkLog
-from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
-from TermTk.TTkCore.color import TTkColor
 from TermTk.TTkWidgets.Fancy.treewidget import TTkFancyTreeWidget
-from TermTk.TTkLayouts.gridlayout import TTkGridLayout
 from TermTk.TTkAbstract.abstractscrollarea import TTkAbstractScrollArea
 
 class TTkFancyTree(TTkAbstractScrollArea):

--- a/TermTk/TTkWidgets/Fancy/treeview.py
+++ b/TermTk/TTkWidgets/Fancy/treeview.py
@@ -22,11 +22,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from TermTk.TTkCore.cfg import TTkCfg
-from TermTk.TTkCore.constant import TTkK
-from TermTk.TTkCore.log import TTkLog
-from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
-from TermTk.TTkCore.color import TTkColor
 from TermTk.TTkWidgets.Fancy.tableview import TTkFancyTableView
 
 class TTkFancyTreeView(TTkFancyTableView):

--- a/TermTk/TTkWidgets/Fancy/treewidget.py
+++ b/TermTk/TTkWidgets/Fancy/treewidget.py
@@ -22,14 +22,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from TermTk.TTkCore.cfg import TTkCfg
 from TermTk.TTkCore.constant import TTkK
 from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
-from TermTk.TTkCore.color import TTkColor
 from TermTk.TTkWidgets.widget import TTkWidget
 from TermTk.TTkWidgets.checkbox import TTkCheckbox
-from TermTk.TTkLayouts.gridlayout import TTkGridLayout
 from TermTk.TTkWidgets.Fancy.tableview import TTkFancyTableView
 from TermTk.TTkWidgets.Fancy.treewidgetitem import TTkFancyTreeWidgetItem
 

--- a/TermTk/TTkWidgets/Fancy/treewidgetitem.py
+++ b/TermTk/TTkWidgets/Fancy/treewidgetitem.py
@@ -22,10 +22,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from TermTk.TTkCore.cfg import TTkCfg
 from TermTk.TTkCore.constant import TTkK
-from TermTk.TTkCore.log import TTkLog
-from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
+from TermTk.TTkCore.signal import pyTTkSignal
 
 class TTkFancyTreeWidgetItem():
     __slots__ = ('_parent', '_data', '_children', '_expand', '_childIndicatorPolicy',

--- a/TermTk/TTkWidgets/TTkModelView/__init__.py
+++ b/TermTk/TTkWidgets/TTkModelView/__init__.py
@@ -1,4 +1,3 @@
-
 from .tree                import TTkTree
 from .treewidget          import TTkTreeWidget
 from .treewidgetitem      import TTkTreeWidgetItem

--- a/TermTk/TTkWidgets/TTkModelView/filetree.py
+++ b/TermTk/TTkWidgets/TTkModelView/filetree.py
@@ -22,8 +22,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from TermTk.TTkCore.constant import TTkK
-from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
 from TermTk.TTkWidgets.TTkModelView.tree import TTkTree
 from TermTk.TTkWidgets.TTkModelView.filetreewidget import TTkFileTreeWidget
 

--- a/TermTk/TTkWidgets/TTkModelView/filetreewidget.py
+++ b/TermTk/TTkWidgets/TTkModelView/filetreewidget.py
@@ -23,13 +23,11 @@
 # SOFTWARE.
 
 import os
-import re
 import datetime
 
 from TermTk.TTkCore.color import TTkColor
 
 from TermTk.TTkCore.constant import TTkK
-from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkCore.cfg import TTkCfg
 from TermTk.TTkCore.string import TTkString
 from TermTk.TTkWidgets.TTkModelView.treewidget import TTkTreeWidget

--- a/TermTk/TTkWidgets/TTkModelView/filetreewidgetitem.py
+++ b/TermTk/TTkWidgets/TTkModelView/filetreewidgetitem.py
@@ -24,14 +24,8 @@
 
 import re
 
-from TermTk.TTkCore.color import TTkColor
-
 from TermTk.TTkCore.constant import TTkK
-from TermTk.TTkCore.log import TTkLog
-from TermTk.TTkCore.cfg import TTkCfg
-from TermTk.TTkCore.string import TTkString
 from TermTk.TTkWidgets.TTkModelView.treewidgetitem import TTkTreeWidgetItem
-from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
 
 class TTkFileTreeWidgetItem(TTkTreeWidgetItem):
     FILE = 0x00

--- a/TermTk/TTkWidgets/TTkModelView/tree.py
+++ b/TermTk/TTkWidgets/TTkModelView/tree.py
@@ -23,8 +23,6 @@
 # SOFTWARE.
 
 from TermTk.TTkCore.constant import TTkK
-from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
-from TermTk.TTkWidgets.TTkModelView import treewidget
 from TermTk.TTkWidgets.TTkModelView.treewidget import TTkTreeWidget
 from TermTk.TTkAbstract.abstractscrollarea import TTkAbstractScrollArea
 

--- a/TermTk/TTkWidgets/TTkModelView/treewidget.py
+++ b/TermTk/TTkWidgets/TTkModelView/treewidget.py
@@ -291,7 +291,7 @@ class TTkTreeWidget(TTkAbstractScrollView):
         for i, c in enumerate(self._cache):
             if i-y<0 : continue
             item  = c.item
-            level = c.level
+            # level = c.level
             for il in range(len(self._header)):
                 lx = 0 if il==0 else self._columnsPos[il-1]+1
                 lx1 = self._columnsPos[il]

--- a/TermTk/TTkWidgets/TTkModelView/treewidget.py
+++ b/TermTk/TTkWidgets/TTkModelView/treewidget.py
@@ -181,7 +181,7 @@ class TTkTreeWidget(TTkAbstractScrollView):
             item  = self._cache[y].item
             level = self._cache[y].level
             if level*2 <= x < level*2+3 and \
-               ( item.childIndicatorPolicy() == TTkK.DontShowIndicatorWhenChildless and item.children() or \
+               ( item.childIndicatorPolicy() == TTkK.DontShowIndicatorWhenChildless and item.children() or
                  item.childIndicatorPolicy() == TTkK.ShowIndicator ):
                 item.setExpanded(not item.isExpanded())
                 if item.isExpanded():

--- a/TermTk/TTkWidgets/TTkModelView/treewidget.py
+++ b/TermTk/TTkWidgets/TTkModelView/treewidget.py
@@ -23,9 +23,7 @@
 # SOFTWARE.
 
 from TermTk.TTkCore.cfg import TTkCfg
-from TermTk.TTkCore.color import TTkColor
 from TermTk.TTkCore.constant import TTkK
-from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkWidgets.TTkModelView.treewidgetitem import TTkTreeWidgetItem
 from TermTk.TTkAbstract.abstractscrollarea import TTkAbstractScrollView
 from TermTk.TTkCore.signal import pyTTkSignal, pyTTkSlot

--- a/TermTk/TTkWidgets/TTkModelView/treewidgetitem.py
+++ b/TermTk/TTkWidgets/TTkModelView/treewidgetitem.py
@@ -184,6 +184,6 @@ class TTkTreeWidgetItem(TTkAbstractItemModel):
 
     def size(self):
         if self._expanded:
-            return 1 + sum([c.size() for c in self.children()])
+            return 1 + sum(c.size() for c in self.children())
         else:
             return 1

--- a/TermTk/TTkWidgets/TTkModelView/treewidgetitem.py
+++ b/TermTk/TTkWidgets/TTkModelView/treewidgetitem.py
@@ -24,8 +24,7 @@
 
 from TermTk.TTkCore.cfg import TTkCfg
 from TermTk.TTkCore.constant import TTkK
-from TermTk.TTkCore.log import TTkLog
-from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
+from TermTk.TTkCore.signal import pyTTkSlot
 from TermTk.TTkAbstract.abstractitemmodel import TTkAbstractItemModel
 
 

--- a/TermTk/TTkWidgets/TTkModelView/treewidgetitem.py
+++ b/TermTk/TTkWidgets/TTkModelView/treewidgetitem.py
@@ -40,7 +40,7 @@ class TTkTreeWidgetItem(TTkAbstractItemModel):
     def __init__(self, *args, **kwargs):
         # Signals
         # self.refreshData = pyTTkSignal(TTkTreeWidgetItem)
-        tt = TTkCfg.theme.tree
+        # tt = TTkCfg.theme.tree
         super().__init__(*args, **kwargs)
         self._children = []
         self._data = args[0] if len(args)>0 and type(args[0])==list else ['']

--- a/TermTk/TTkWidgets/TTkPickers/colorpicker.py
+++ b/TermTk/TTkWidgets/TTkPickers/colorpicker.py
@@ -83,7 +83,7 @@ class _TTkHueCanvas(TTkWidget):
                     rgb =a|(b&_linInt(0,b,6*x/w))
                 else:
                     rgb =a|(b&_linInt(b,0,6*x/w))
-                color = TTkColor.bg( "#{:06x}".format(rgb) )
+                color = TTkColor.bg( f"#{rgb:06x}" )
                 if (num*w//6)+x == self._selected:
                     self._canvas.drawChar(pos=((num*w//6)+x,0), char="◼", color=color+TTkColor.fg("#000000"))
                 else:
@@ -144,7 +144,7 @@ class _TTkColorCanvas(TTkWidget):
         w,h = self.size()
         for x in range(w):
             for y in range(h):
-                color = TTkColor.bg( "#{:06x}".format(self._colorAt(x,y,w,h)) )
+                color = TTkColor.bg( f"#{self._colorAt(x,y,w,h):06x}" )
                 if (x,y)==self._selected:
                     self._canvas.drawText(pos=(x,y), text="◼", color=color+TTkColor.fg("#000000"))
                 else:
@@ -158,7 +158,7 @@ class _TTkShowColor(TTkWidget,TColor):
 
     @pyTTkSlot(int)
     def setRGBColor(self, color):
-        self.color = TTkColor.bg( "#{:06x}".format(color) )
+        self.color = TTkColor.bg( f"#{color:06x}" )
         self.update()
 
     @pyTTkSlot(TTkColor)
@@ -296,7 +296,7 @@ class TTkColorDialogPicker(TTkWindow,TColor):
             leR.setValue((color&0xff0000)>>16)
             leG.setValue((color&0x00ff00)>> 8)
             leB.setValue((color&0x0000ff)>> 0)
-            leHTML.setText("#{:06X}".format(color))
+            leHTML.setText(f"#{color:06X}")
 
         @pyTTkSlot(TTkColor)
         def _controlSetColor(color):

--- a/TermTk/TTkWidgets/TTkPickers/colorpicker.py
+++ b/TermTk/TTkWidgets/TTkPickers/colorpicker.py
@@ -33,7 +33,6 @@ from TermTk.TTkCore.helper import TTkHelper
 from TermTk.TTkWidgets.widget import TTkWidget
 from TermTk.TTkWidgets.window import TTkWindow
 from TermTk.TTkWidgets.button import TTkButton
-from TermTk.TTkWidgets.frame import TTkFrame
 from TermTk.TTkWidgets.label import TTkLabel
 from TermTk.TTkWidgets.lineedit import TTkLineEdit
 from TermTk.TTkWidgets.spinbox import TTkSpinBox

--- a/TermTk/TTkWidgets/TTkPickers/colorpicker.py
+++ b/TermTk/TTkWidgets/TTkPickers/colorpicker.py
@@ -61,10 +61,9 @@ class _TTkHueCanvas(TTkWidget):
         self._selected = -1
 
     def mousePressEvent(self, evt):
-        x,y = evt.x, evt.y
-        self._selected = x
-        if x < len(self._hueList):
-            self.colorPicked.emit(self._hueList[x])
+        self._selected = evt.x
+        if evt.x < len(self._hueList):
+            self.colorPicked.emit(self._hueList[evt.x])
         self.update()
         return True
 

--- a/TermTk/TTkWidgets/TTkPickers/filepicker.py
+++ b/TermTk/TTkWidgets/TTkPickers/filepicker.py
@@ -113,7 +113,7 @@ class TTkFileDialogPicker(TTkWindow):
         self._btnCancel = TTkButton(text="Cancel",maxWidth=8)
 
         for f in self._filters.split(';;'):
-            if m := re.match(".*\(.*\)",f):
+            if _ := re.match(".*\(.*\)",f):
                 self._fileType.addItem(f)
         self._fileType.setCurrentIndex(0)
         self._fileType.currentTextChanged.connect(self._fileTypeChanged)

--- a/TermTk/TTkWidgets/TTkPickers/filepicker.py
+++ b/TermTk/TTkWidgets/TTkPickers/filepicker.py
@@ -28,7 +28,6 @@ import re
 from TermTk.TTkCore.color import TTkColor
 
 from TermTk.TTkCore.constant import TTkK
-from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkCore.cfg import TTkCfg
 from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
 from TermTk.TTkCore.string import TTkString

--- a/TermTk/TTkWidgets/TTkPickers/filepicker.py
+++ b/TermTk/TTkWidgets/TTkPickers/filepicker.py
@@ -263,5 +263,6 @@ class TTkFileDialogPicker(TTkWindow):
                 break
         return ret
 class TTkFileDialog:
+    @staticmethod
     def getOpenFileName(caption, dir=".", filter="All Files (*)", options=None):
         pass

--- a/TermTk/TTkWidgets/about.py
+++ b/TermTk/TTkWidgets/about.py
@@ -76,7 +76,7 @@ class TTkAbout(TTkWindow):
             self._canvas.drawText(pos=(9,3+y),text=line, color=TTkColor.fg(f'#{c[0]:02X}{c[1]:02X}{c[2]:02X}'))
             c[2]-=0x11
         self._canvas.drawText(pos=(20,9),text=f"  Version: {TTkCfg.version}", color=TTkColor.fg('#AAAAFF'))
-        self._canvas.drawText(pos=(12,11),text=f"Powered By, Eugenio Parodi")
-        self._canvas.drawText(pos=(2,13),text=f"https://github.com/ceccopierangiolieugenio/pyTermTk", color=TTkColor.fg('#44FFFF'))
+        self._canvas.drawText(pos=(12,11),text="Powered By, Eugenio Parodi")
+        self._canvas.drawText(pos=(2,13),text="https://github.com/ceccopierangiolieugenio/pyTermTk", color=TTkColor.fg('#44FFFF'))
 
         TTkWindow.paintEvent(self)

--- a/TermTk/TTkWidgets/about.py
+++ b/TermTk/TTkWidgets/about.py
@@ -22,10 +22,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkCore.cfg import TTkCfg
 from TermTk.TTkCore.color import TTkColor
-from TermTk.TTkCore.string import TTkString
 from TermTk.TTkWidgets.window import TTkWindow
 from TermTk.TTkWidgets.image import TTkImage
 

--- a/TermTk/TTkWidgets/button.py
+++ b/TermTk/TTkWidgets/button.py
@@ -23,9 +23,7 @@
 # SOFTWARE.
 
 from TermTk.TTkCore.cfg import TTkCfg
-from TermTk.TTkCore.log import TTkLog
-from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
-from TermTk.TTkCore.color import TTkColor
+from TermTk.TTkCore.signal import pyTTkSignal
 from TermTk.TTkWidgets.widget import *
 
 class TTkButton(TTkWidget):

--- a/TermTk/TTkWidgets/checkbox.py
+++ b/TermTk/TTkWidgets/checkbox.py
@@ -23,9 +23,7 @@
 # SOFTWARE.
 
 from TermTk.TTkCore.cfg import TTkCfg
-from TermTk.TTkCore.log import TTkLog
-from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
-from TermTk.TTkCore.color import TTkColor
+from TermTk.TTkCore.signal import pyTTkSignal
 from TermTk.TTkWidgets.widget import *
 
 class TTkCheckbox(TTkWidget):

--- a/TermTk/TTkWidgets/combobox.py
+++ b/TermTk/TTkWidgets/combobox.py
@@ -26,11 +26,9 @@ from TermTk.TTkCore.cfg import TTkCfg
 from TermTk.TTkCore.constant import TTkK
 from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
-from TermTk.TTkCore.color import TTkColor
 from TermTk.TTkCore.helper import TTkHelper
 from TermTk.TTkLayouts.gridlayout import TTkGridLayout
 from TermTk.TTkWidgets.widget import TTkWidget
-from TermTk.TTkWidgets.button import TTkButton
 from TermTk.TTkWidgets.list_ import TTkList
 from TermTk.TTkWidgets.lineedit import TTkLineEdit
 from TermTk.TTkWidgets.resizableframe import TTkResizableFrame

--- a/TermTk/TTkWidgets/frame.py
+++ b/TermTk/TTkWidgets/frame.py
@@ -23,8 +23,6 @@
 # SOFTWARE.
 
 from TermTk.TTkCore.cfg import *
-from TermTk.TTkCore.helper import TTkHelper
-from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkWidgets.widget import TTkWidget
 from TermTk.TTkWidgets.menubar import TTkMenuLayout
 

--- a/TermTk/TTkWidgets/graph.py
+++ b/TermTk/TTkWidgets/graph.py
@@ -29,7 +29,6 @@
 
 from TermTk.TTkCore.cfg import *
 from TermTk.TTkCore.constant import TTkK
-from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkWidgets.widget import TTkWidget
 from TermTk.TTkTemplates.color import TColor
 

--- a/TermTk/TTkWidgets/image.py
+++ b/TermTk/TTkWidgets/image.py
@@ -34,7 +34,7 @@ class TTkImage(TTkWidget):
         self._name = kwargs.get('name' , 'TTkImage' )
         self._data = kwargs.get('data' , [] )
         if self._data:
-            w = min([len(i) for i in self._data])
+            w = min(len(i) for i in self._data)
             h = len(self._data)
             self.resize(w//2,h//2)
 
@@ -42,7 +42,7 @@ class TTkImage(TTkWidget):
         # quadblitter notcurses like
         l = (a,b,c,d)
         def delta(i):
-            return max([v[i] for v in l]) - min([v[i] for v in l])
+            return max(v[i] for v in l) - min(v[i] for v in l)
         deltaR = delta(0)
         deltaG = delta(1)
         deltaB = delta(2)

--- a/TermTk/TTkWidgets/image.py
+++ b/TermTk/TTkWidgets/image.py
@@ -87,7 +87,7 @@ class TTkImage(TTkWidget):
                      '▄', '▙', '▟', '█']
 
             return  TTkString() + \
-                    (TTkColor.bg(f'#{c1[0]:02X}{c1[1]:02X}{c1[2]:02X}') + \
+                    (TTkColor.bg(f'#{c1[0]:02X}{c1[1]:02X}{c1[2]:02X}') +
                      TTkColor.fg(f'#{c2[0]:02X}{c2[1]:02X}{c2[2]:02X}')) + \
                     quad[ch]
 
@@ -172,8 +172,8 @@ class TTkImage(TTkWidget):
         img = self._data
         for y in range(0, len(img)&(~1), 2):
             for x in range(0, min(len(img[y])&(~1),len(img[y+1])&(~1)), 2):
-                self._canvas.drawText( \
-                        pos=(x//2,y//2), \
+                self._canvas.drawText(
+                        pos=(x//2,y//2),
                         text=self._reduce(
                                     img[y][x]   , img[y][x+1]   ,
                                     img[y+1][x] , img[y+1][x+1] ))

--- a/TermTk/TTkWidgets/image.py
+++ b/TermTk/TTkWidgets/image.py
@@ -22,7 +22,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkCore.color import TTkColor
 from TermTk.TTkCore.string import TTkString
 from TermTk.TTkWidgets.widget import TTkWidget

--- a/TermTk/TTkWidgets/label.py
+++ b/TermTk/TTkWidgets/label.py
@@ -23,7 +23,6 @@
 # SOFTWARE.
 
 from TermTk.TTkCore.color import TTkColor
-from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkWidgets.widget import *
 from TermTk.TTkTemplates.color import TColor
 from TermTk.TTkTemplates.text  import TText

--- a/TermTk/TTkWidgets/lineedit.py
+++ b/TermTk/TTkWidgets/lineedit.py
@@ -25,7 +25,6 @@
 import re
 
 from TermTk.TTkCore.cfg import TTkCfg
-from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkCore.helper import TTkHelper
 from TermTk.TTkCore.string import TTkString
 from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal

--- a/TermTk/TTkWidgets/lineedit.py
+++ b/TermTk/TTkWidgets/lineedit.py
@@ -164,7 +164,7 @@ class TTkLineEdit(TTkWidget):
         return True
 
     def keyEvent(self, evt):
-        w = self.width()
+        # w = self.width()
         baseText = self._text
         if evt.type == TTkK.SpecialKey:
             # Don't Handle the special tab key

--- a/TermTk/TTkWidgets/list_.py
+++ b/TermTk/TTkWidgets/list_.py
@@ -22,10 +22,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from TermTk.TTkCore.cfg import TTkCfg
-from TermTk.TTkCore.constant import TTkK
-from TermTk.TTkCore.log import TTkLog
-from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
 from TermTk.TTkWidgets.listwidget import TTkListWidget
 from TermTk.TTkAbstract.abstractscrollarea import TTkAbstractScrollArea
 

--- a/TermTk/TTkWidgets/menubar.py
+++ b/TermTk/TTkWidgets/menubar.py
@@ -26,7 +26,6 @@ from TermTk.TTkCore.cfg import *
 from TermTk.TTkCore.helper import TTkHelper
 from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkCore.signal import pyTTkSignal, pyTTkSlot
-from TermTk.TTkWidgets.widget import TTkWidget
 from TermTk.TTkWidgets.button import TTkButton
 from TermTk.TTkWidgets.listwidget import TTkListWidget, TTkAbstractListItem
 from TermTk.TTkLayouts.layout import TTkLayout

--- a/TermTk/TTkWidgets/radiobutton.py
+++ b/TermTk/TTkWidgets/radiobutton.py
@@ -23,9 +23,7 @@
 # SOFTWARE.
 
 from TermTk.TTkCore.cfg import TTkCfg
-from TermTk.TTkCore.log import TTkLog
-from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
-from TermTk.TTkCore.color import TTkColor
+from TermTk.TTkCore.signal import pyTTkSignal
 from TermTk.TTkWidgets.widget import *
 
 class TTkRadioButton(TTkWidget):

--- a/TermTk/TTkWidgets/resizableframe.py
+++ b/TermTk/TTkWidgets/resizableframe.py
@@ -23,7 +23,6 @@
 # SOFTWARE.
 
 from TermTk.TTkCore.constant import TTkK
-from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkWidgets.frame import TTkFrame
 
 class TTkResizableFrame(TTkFrame):

--- a/TermTk/TTkWidgets/scrollarea.py
+++ b/TermTk/TTkWidgets/scrollarea.py
@@ -22,9 +22,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from TermTk.TTkCore.log import TTkLog
-from TermTk.TTkCore.constant import TTkConstant, TTkK
-from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
+from TermTk.TTkCore.constant import TTkK
+from TermTk.TTkCore.signal import pyTTkSlot
 from TermTk.TTkAbstract.abstractscrollarea import TTkAbstractScrollArea
 from TermTk.TTkAbstract.abstractscrollview import TTkAbstractScrollView
 

--- a/TermTk/TTkWidgets/scrollbar.py
+++ b/TermTk/TTkWidgets/scrollbar.py
@@ -23,7 +23,6 @@
 # SOFTWARE.
 
 from TermTk.TTkCore.constant import TTkK
-from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
 from TermTk.TTkCore.color import TTkColor
 from TermTk.TTkWidgets.widget import TTkWidget

--- a/TermTk/TTkWidgets/scrollbar.py
+++ b/TermTk/TTkWidgets/scrollbar.py
@@ -218,7 +218,7 @@ class TTkScrollBar(TTkWidget):
 
     @property
     def maximum(self): return self._maximum
-    @minimum.setter
+    @maximum.setter
     def maximum(self, v):
         if v == self._maximum:
             return

--- a/TermTk/TTkWidgets/spacer.py
+++ b/TermTk/TTkWidgets/spacer.py
@@ -22,7 +22,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkWidgets.widget import TTkWidget
 
 class TTkSpacer(TTkWidget):

--- a/TermTk/TTkWidgets/spinbox.py
+++ b/TermTk/TTkWidgets/spinbox.py
@@ -23,11 +23,7 @@
 # SOFTWARE.
 
 from TermTk.TTkCore.constant import TTkK
-from TermTk.TTkCore.cfg import TTkCfg
-from TermTk.TTkCore.log import TTkLog
-from TermTk.TTkCore.helper import TTkHelper
 from TermTk.TTkCore.signal import pyTTkSlot, pyTTkSignal
-from TermTk.TTkCore.color import TTkColor
 from TermTk.TTkLayouts import TTkGridLayout
 from TermTk.TTkWidgets.widget import TTkWidget
 from TermTk.TTkWidgets.lineedit import TTkLineEdit

--- a/TermTk/TTkWidgets/splitter.py
+++ b/TermTk/TTkWidgets/splitter.py
@@ -51,10 +51,10 @@ class TTkSplitter(TTkFrame):
         self._splitterInitialized = True
 
         class _SplitterLayout(TTkLayout):
-            @staticmethod
+            # Use dunder instead of 'self' in non-static methods to avoid
+            # recursion.
             def insertWidget(_, index, widget):
                 self.insertWidget(index, widget)
-            @staticmethod
             def addWidget(_, widget):
                 self.addWidget(widget)
         self.setLayout(_SplitterLayout())

--- a/TermTk/TTkWidgets/splitter.py
+++ b/TermTk/TTkWidgets/splitter.py
@@ -51,8 +51,10 @@ class TTkSplitter(TTkFrame):
         self._splitterInitialized = True
 
         class _SplitterLayout(TTkLayout):
+            @staticmethod
             def insertWidget(_, index, widget):
                 self.insertWidget(index, widget)
+            @staticmethod
             def addWidget(_, widget):
                 self.addWidget(widget)
         self.setLayout(_SplitterLayout())

--- a/TermTk/TTkWidgets/splitter.py
+++ b/TermTk/TTkWidgets/splitter.py
@@ -23,8 +23,6 @@
 # SOFTWARE.
 
 from TermTk.TTkCore.constant import TTkK
-from TermTk.TTkCore.log import TTkLog
-from TermTk.TTkCore.color import TTkColor
 from TermTk.TTkWidgets.widget import *
 from TermTk.TTkWidgets.frame import *
 

--- a/TermTk/TTkWidgets/tabwidget.py
+++ b/TermTk/TTkWidgets/tabwidget.py
@@ -134,11 +134,11 @@ class _TTkTabMenuButton(TTkMenuButton):
         if self._pressed:
             borderColor = self._borderColor
             textColor   = TTkCfg.theme.menuButtonColorClicked
-            scColor     = TTkCfg.theme.menuButtonShortcutColor
+            # scColor     = TTkCfg.theme.menuButtonShortcutColor
         else:
             borderColor = self._borderColor
             textColor   = self._color
-            scColor     =  TTkCfg.theme.menuButtonShortcutColor
+            # scColor     =  TTkCfg.theme.menuButtonShortcutColor
         text = TTkString('[',borderColor) + TTkString(self.text,textColor) + TTkString(']',borderColor)
         self._canvas.drawText(pos=(0,0),text=text)
 

--- a/TermTk/TTkWidgets/tabwidget.py
+++ b/TermTk/TTkWidgets/tabwidget.py
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from TermTk.TTkCore.constant import TTkConstant, TTkK
+from TermTk.TTkCore.constant import  TTkK
 from TermTk.TTkCore.helper import TTkHelper
 from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkCore.cfg import *

--- a/TermTk/TTkWidgets/texedit.py
+++ b/TermTk/TTkWidgets/texedit.py
@@ -22,12 +22,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkWidgets.widget import *
-from TermTk.TTkLayouts.gridlayout import TTkGridLayout
-from TermTk.TTkCore.color import TTkColor
 from TermTk.TTkCore.string import TTkString
-from TermTk.TTkWidgets.scrollbar import TTkScrollBar
 from TermTk.TTkAbstract.abstractscrollarea import TTkAbstractScrollArea
 from TermTk.TTkAbstract.abstractscrollview import TTkAbstractScrollView
 

--- a/TermTk/TTkWidgets/texedit.py
+++ b/TermTk/TTkWidgets/texedit.py
@@ -158,7 +158,7 @@ class _TTkTextEditView(TTkAbstractScrollView):
         return super().resizeEvent(w,h)
 
     def _updateSize(self):
-        self._hsize = max( [ len(l) for l in self._dataLines ] )
+        self._hsize = max(  len(l) for l in self._dataLines  )
 
     def viewFullAreaSize(self) -> (int, int):
         if self._lineWrapMode == TTkK.NoWrap:

--- a/TermTk/TTkWidgets/window.py
+++ b/TermTk/TTkWidgets/window.py
@@ -24,10 +24,8 @@
 
 from TermTk.TTkCore.cfg import TTkCfg
 from TermTk.TTkCore.constant import TTkK
-from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkCore.color import TTkColor
 from TermTk.TTkWidgets.resizableframe import TTkResizableFrame
-from TermTk.TTkWidgets.widget import TTkWidget
 
 
 class TTkWindow(TTkResizableFrame):


### PR DESCRIPTION
Use format string since project is >=3.8 anyway
Avoid double lists
Comment out unused vars which are confusing
Comment double declared method
Repair maximum setter
Remove format call where not needed
Remove redundant backslash within brackets
Add comment on _SplitterLayout to explain dunder usage
Remove unused imports