### PR TITLE
Fix: TTkString alignment (at _hasSpecialWidth)

### DIFF
--- a/TermTk/TTkCore/string.py
+++ b/TermTk/TTkCore/string.py
@@ -309,19 +309,18 @@ class TTkString():
             rt = ""
             sz = 0
             for ch in self._text:
+                rt += ch
                 if unicodedata.category(ch) in ('Me','Mn'):
-                    rt += ch
                     continue
-                delta_sz = 2 if unicodedata.east_asian_width(ch) == 'W' else 1 # (*)
-                if sz + delta_sz <= width:
-                    rt += ch
-                    sz += delta_sz
-                    if sz == width:
-                        ret._text   = rt
-                        ret._colors = self._colors[:len(rt)]
-                        break
-                else: # sz +delta_sz == width + 1, because of (*)
-                    ret._text   =  rt+TTkCfg.theme.unicodeWideOverflowCh[1]
+
+                sz += 2 if unicodedata.east_asian_width(ch) == 'W' else 1
+
+                if sz == width:
+                    ret._text   =  rt
+                    ret._colors =  self._colors[:len(rt)]
+                    break
+                elif sz > width:
+                    ret._text   =  rt[:-1]+TTkCfg.theme.unicodeWideOverflowCh[1]
                     ret._colors =  self._colors[:len(ret._text)]
                     ret._colors[-1] = TTkCfg.theme.unicodeWideOverflowColor
                     break

--- a/TermTk/TTkCore/string.py
+++ b/TermTk/TTkCore/string.py
@@ -312,17 +312,19 @@ class TTkString():
                 if unicodedata.category(ch) in ('Me','Mn'):
                     rt += ch
                     continue
-                if sz == width:
-                    ret._text   =  rt
-                    ret._colors =  self._colors[:len(rt)]
-                    break
-                elif sz > width:
-                    ret._text   =  rt[:-1]+TTkCfg.theme.unicodeWideOverflowCh[1]
+                delta_sz = 2 if unicodedata.east_asian_width(ch) == 'W' else 1 # (*)
+                if sz + delta_sz <= width:
+                    rt += ch
+                    sz += delta_sz
+                    if sz == width:
+                        ret._text   = rt
+                        ret._colors = self._colors[:len(rt)]
+                        break
+                else: # sz +delta_sz == width + 1, because of (*)
+                    ret._text   =  rt+TTkCfg.theme.unicodeWideOverflowCh[1]
                     ret._colors =  self._colors[:len(ret._text)]
                     ret._colors[-1] = TTkCfg.theme.unicodeWideOverflowColor
                     break
-                rt += ch
-                sz += 2 if unicodedata.east_asian_width(ch) == 'W' else 1
         else:
             # Legacy, trim the string
             ret._text   =  self._text[:width]


### PR DESCRIPTION
There was/is a small logical error in the `ch`-loop at the `align` method. The last codepoint isn't added if it is too wide (and the whole `ret` is not set) .

Testcase
```python
import TermTk

root = TermTk.TTk()  # in order to have TTkCfg.theme

test1 = TermTk.TTkString('Yes\u231b\u231b\u231b') # 'Yes⌛⌛⌛'

print(f"Testcase: |{str(test1)}|")

for width in range(1, 13):
    aligned = test1.align(width=width, alignment=TermTk.TTkK.CENTER_ALIGN)
    print(f"width={width:2}: |{aligned}|")
```

Result befor this PR:
```
Testcase: |Yes⌛⌛⌛|
width= 1: |Y|
width= 2: |Ye|
width= 3: |Yes|
width= 4: |Yes≽|
width= 5: |Yes⌛|
width= 6: |Yes⌛≽|
width= 7: |Yes⌛⌛|
width= 8: ||
width= 9: |Yes⌛⌛⌛|
width=10: |Yes⌛⌛⌛ |
width=11: | Yes⌛⌛⌛ |
width=12: | Yes⌛⌛⌛  |
```

after this PR:
```
Testcase: |Yes⌛⌛⌛|
width= 1: |Y|
width= 2: |Ye|
width= 3: |Yes|
width= 4: |Yes≽|
width= 5: |Yes⌛|
width= 6: |Yes⌛≽|
width= 7: |Yes⌛⌛|
width= 8: |Yes⌛⌛≽|
width= 9: |Yes⌛⌛⌛|
width=10: |Yes⌛⌛⌛ |
width=11: | Yes⌛⌛⌛ |
width=12: | Yes⌛⌛⌛  |
```
