### PR TITLE
TTkLabel: use termWidth

### DIFF
--- a/TermTk/TTkTemplates/text.py
+++ b/TermTk/TTkTemplates/text.py
@@ -46,5 +46,5 @@ class TText():
                 self._text  = text
             else:
                 self._text  = TTkString(text)
-            self.textUpdated(text)
+            self.textUpdated(self._text)
 

--- a/TermTk/TTkWidgets/label.py
+++ b/TermTk/TTkWidgets/label.py
@@ -33,11 +33,11 @@ class TTkLabel(TTkWidget, TColor, TText):
         TColor.__init__(self, *args, **kwargs)
         TText.__init__(self, *args, **kwargs)
 
-        self.setDefaultSize(kwargs, len(self.text), 1)
+        self.setDefaultSize(kwargs, self.text.termWidth(), 1)
 
         TTkWidget.__init__(self, *args, **kwargs)
         self._name = kwargs.get('name' , 'TTkLabel' )
-        # self.setMinimumSize(len(self.text), 1)
+        # self.setMinimumSize(self.text.termWidth(), 1)
         self.textUpdated(self.text)
 
     @pyTTkSlot(str)
@@ -51,9 +51,10 @@ class TTkLabel(TTkWidget, TColor, TText):
 
     def textUpdated(self, text):
         w, h = self.size()
-        if w<len(text) or h<1:
-            self.resize(len(text),1)
-        self.setMinimumSize(len(text), 1)
+        textWidth = text.termWidth()
+        if w<textWidth or h<1:
+            self.resize(textWidth,1)
+        self.setMinimumSize(textWidth, 1)
         self.update()
 
     def colorUpdated(self, color):


### PR DESCRIPTION
More steps for the "use `termWidth` migration":

* Use (already constructed) `TTkString` in `TText`s method `textUpdates`
* TTkLabel: use `termWidth` (of `TTkString`) for width computations
