### PR TITLE
Delete variation selector examples in (demo-) test widgets

### DIFF
--- a/TermTk/TTkTestWidgets/testwidget.py
+++ b/TermTk/TTkTestWidgets/testwidget.py
@@ -33,7 +33,7 @@ from TermTk.TTkWidgets.frame import *
 class _TestContent(TTkWidget):
     def paintEvent(self):
         # TTkLog.debug(f"Test Paint - {self._name}")
-        y=0;  self._canvas.drawText(pos=(-5,y),text=TTkString(color=TTkColor.fg("#ff0000") ,text="     L😎rem ipsum dolor sit amet, ⌚⌚︎⌚️  ❤❤︎❤️  🙋🙋︎🙋️'"))
+        y=0;  self._canvas.drawText(pos=(-5,y),text=TTkString(color=TTkColor.fg("#ff0000") ,text="     L😎rem ipsum dolor sit amet, ⌚ ❤ 💙 🙋'"))
         y+=1; self._canvas.drawText(pos=(0,y), text=TTkString(color=TTkColor.fg("#ff8800") ,text="consectetur adipiscing elit,"))
         y+=1; self._canvas.drawText(pos=(0,y), text=TTkString(color=TTkColor.fg("#ffff00") ,text="sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."))
         y+=1; self._canvas.drawText(pos=(0,y), text=TTkString(color=TTkColor.fg("#00ff00") ,text="Ut enim ad minim veniam,"))


### PR DESCRIPTION
Because pyTermTk's terminal-width-approximation doesn't take into account Unicode Variation Selectors (in a way which is appropriate for every terminal) and the Test-Widgets are used in the demo: delete the examples with Variation Selectors.

Otherwise there are glitches (in some terminals) in the demo which is not nice for a demo.

