### PR TITLE
Proof of concept: Weakref signalslots

### DIFF
--- a/TermTk/TTkCore/signal.py
+++ b/TermTk/TTkCore/signal.py
@@ -98,6 +98,12 @@ class WeakrefSlot:
         self._weak_slotref = (
             weakref.WeakMethod(slot) if bound_method else weakref.ref(slot))
 
+    def __str__(self):
+        '''show target (if avail).'''
+        target = None if self._referent_gone else self._weak_slotref()
+        target_str = 'dead' if target is None else f'to {str(target)}'
+        return f'<{self.__class__.__name__} at {hex(id(self))}; {target_str}>'
+
     def __call__(self, *args, **kwargs):
         '''
         If the referent of _weak_slotref was not garbage collected, then

--- a/TermTk/TTkCore/signal.py
+++ b/TermTk/TTkCore/signal.py
@@ -56,6 +56,66 @@ Methods
 .. autofunction:: TermTk.pyTTkSignal
 .. autodecorator:: TermTk.pyTTkSlot
 '''
+
+import weakref
+
+class WeakrefSlot:
+    '''
+    A WeakrefSlot instance saves a slot as weakref (or WeakMethod).
+
+    Hence the slots may be garbage collected, leaving this WeakrefSlot
+    without a referent.
+
+    WeakrefSlots are callable. They call the referent slot (if available).
+
+    WeakrefSlots have no __eq__ method hence they are compared with
+    python's "is" operator (identitiy check). This is important for
+    WekrefSlots inside lists.
+
+    WeakrefSlots have the _referent_gone flag which is set after the
+    WeakrefSlot has detected that the referent was already garbage
+    collected. This flag may be used to easily delete WeakrefSlots
+    without referents.
+    '''
+    __slots__ = ('_weak_slotref', '_referent_gone')
+
+    def __init__(self, slot):
+        '''
+        initialize WekrefSlot for the input argument slot (which must be callable).
+
+        WeakMethod is used for bounded methods.
+
+        Attention:
+        A slot object which has no (other) references than the given
+        slot may be garbage collected immediately after this call.
+        They are "dead on arrival". A typical example for this is a
+        inline lambda function. That's *the* feature of WeakrefSlots.
+        '''
+        if not callable(slot):
+            raise TypeError(f'slot must be callable; I found {type(slot)=}')
+        self._referent_gone = False
+        bound_method = hasattr(slot, '__self__')  and  hasattr(slot, '__func__')
+        self._weak_slotref = (
+            weakref.WeakMethod(slot) if bound_method else weakref.ref(slot))
+
+    def __call__(self, *args, **kwargs):
+        '''
+        If the referent of _weak_slotref was not garbage collected, then
+        call the referent.
+
+        Checks and updates _referent_gone flag.
+        '''
+        if self._referent_gone:
+            return  # Nothing to do; we already know the referent is gone
+        func = self._weak_slotref()
+        if func is None:
+            # referent was gargabe collected (since the last test)
+            self._referent_gone = True
+            return # Nothing to do
+        func(*args, **kwargs)  # call referent slot
+        # throw away the (strong) reference "func" now
+
+
 def pyTTkSlot(*args, **kwargs):
     def pyTTkSlot_d(func):
         # Add signature attributes to the function
@@ -88,7 +148,7 @@ class _pyTTkSignal_obj():
         self._connected_slots = []
         _pyTTkSignal_obj._signals.append(self)
 
-    def connect(self, slot):
+    def connect(self, slot, use_weak_ref=False):
         # ref: http://pyqt.sourceforge.net/Docs/PyQt5/signals_slots.html#connect
 
         # connect(slot[, type=PyQt5.QtCore.Qt.AutoConnection[, no_receiver_check=False]]) -> PyQt5.QtCore.QMetaObject.Connection
@@ -108,8 +168,11 @@ class _pyTTkSignal_obj():
                 if not issubclass(a,b):
                     error = "Decorated slot has no signature compatible: "+slot.__name__+str(slot._TTkslot_attr)+" != signal"+str(self._types)
                     raise TypeError(error)
+        if use_weak_ref:
+            slot = WeakrefSlot(slot)  # replace slot with WeakrefSlot
         if slot not in self._connected_slots:
             self._connected_slots.append(slot)
+        return slot # may return WeakrefSlot which may be used for disconnect
 
     def disconnect(self, *args, **kwargs):
         for slot in args:
@@ -120,8 +183,18 @@ class _pyTTkSignal_obj():
         if len(args) != len(self._types):
             error = "func"+str(self._types)+" signal has "+str(len(self._types))+" argument(s) but "+str(len(args))+" provided"
             raise TypeError(error)
+
+        need_weakref_cleanup = False  # have we seen WeakrefSlots without referent?
         for slot in self._connected_slots:
             slot(*args, **kwargs)
+            if isinstance(slot, WeakrefSlot)  and  slot._referent_gone:
+                need_weakref_cleanup = True
+
+        if need_weakref_cleanup:
+            # remove WeakrefSlots where referent was gone
+            for slot in self._connected_slots[:]: # do a slice for safe removal
+                if isinstance(slot, WeakrefSlot)  and  slot._referent_gone:
+                    self._connected_slots.remove(slot)
 
     def clear(self):
         self._connected_slots = []

--- a/TermTk/TTkWidgets/widget.py
+++ b/TermTk/TTkWidgets/widget.py
@@ -658,4 +658,4 @@ class TTkWidget(TMouseEvents,TKeyEvents, TDragEvents):
         if not laf:
             laf = TTkLookAndFeel()
         self._lookAndFeel = laf
-        self._lookAndFeel.modified.connect(self.update)
+        self._lookAndFeel.modified.connect(self.update, use_weak_ref=True)

--- a/TermTk/TTkWidgets/window.py
+++ b/TermTk/TTkWidgets/window.py
@@ -34,10 +34,13 @@ class _MinimizedButton(TTkButton):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._windowWidget = kwargs.get('windowWidget')
-        def _cb():
+        self.clicked.connect(self.perfomAction, use_weak_ref=True)
+
+    def perfomAction(self):
+        '''show _windowWidget and close self.'''
+        if self._windowWidget is not None:
             self._windowWidget.show()
-            self.close()
-        self.clicked.connect(_cb)
+        self.close()
 
 class TTkWindow(TTkResizableFrame):
     __slots__ = (
@@ -61,18 +64,18 @@ class TTkWindow(TTkResizableFrame):
         self.rootLayout().addItem(self._winTopLayout)
         # Close Button
         self._btnClose = TTkButton(border=False, text="x", size=(3,1), maxWidth=3, minWidth=3, visible=False)
-        self._btnClose.clicked.connect(self.close)
+        self._btnClose.clicked.connect(self.close, use_weak_ref=True)
         # Max Button
         self._maxBk = None
         self._btnMax = TTkButton(border=False, text="^", size=(3,1), maxWidth=3, minWidth=3, visible=False)
-        self._btnMax.clicked.connect(self._maximize)
+        self._btnMax.clicked.connect(self._maximize, use_weak_ref=True)
         # Min Button
         self._btnMin = TTkButton(border=False, text="_", size=(3,1), maxWidth=3, minWidth=3, visible=False)
-        self._btnMin.clicked.connect(self._minimize)
+        self._btnMin.clicked.connect(self._minimize, use_weak_ref=True)
         # Button Reduce_border
         self._redBk = None
         self._btnReduce = TTkButton(border=False, text=".", size=(3,1), maxWidth=3, minWidth=3, visible=False)
-        self._btnReduce.clicked.connect(self._reduce)
+        self._btnReduce.clicked.connect(self._reduce, use_weak_ref=True)
 
         self._winTopLayout.addItem(TTkLayout(),0,0)
         self._winTopLayout.addWidget(self._btnClose, 0,4)

--- a/tests/test.ui.024.weakslots.py
+++ b/tests/test.ui.024.weakslots.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# vim:ts=4:sw=4:fdm=indent:cc=79:
+
+# MIT License
+#
+# Copyright (c) 2022 Luchr  <https://github.com/luchr>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import datetime
+import gc
+
+import TermTk
+
+WIN_COUNTER = 0
+
+class ShowEventWindow(TermTk.TTkWindow):
+    __slots__ = ('_win_number', '_event_info')
+
+    def __init__(self, parent, event):
+        global WIN_COUNTER
+        WIN_COUNTER += 1
+        win_number = WIN_COUNTER
+        self._win_number = win_number
+        win_layout = TermTk.TTkGridLayout(columnMinHeight=1)
+        TermTk.TTkWindow.__init__(
+            self, parent=parent, pos=(10, 18+win_number), size=(45, 5),
+            title=f'Window {win_number}',
+            layout=win_layout)
+        if win_number == 1:
+            self.setWindowFlag(0x0)
+        self._event_info = TermTk.TTkLabel(
+            text='updated if main button is clicked')
+        win_layout.addWidget(self._event_info, 0, 0)
+        event.connect(self.show_event, use_weak_ref=True)
+
+    def show_event(self):
+        now = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        self._event_info.setText(f'last seen event: {now}')
+        TermTk.TTkLog.debug(f'show_event of window {self._win_number}')
+        gc.collect()
+        refs = gc.get_referrers(self)
+        TermTk.TTkLog.debug(f'{len(refs)=}')
+        for ref in refs:
+            TermTk.TTkLog.debug(f'{id(ref)=}: {repr(ref)}')
+
+
+class MainWindow(TermTk.TTkWindow):
+    __slots__ = ('_main_button', '_slot_info', '_info_timer', '_timer_delay')
+
+    def __init__(self, parent, timer_delay):
+        self._timer_delay = timer_delay
+        win_layout = TermTk.TTkGridLayout(columnMinHeight=1)
+        TermTk.TTkWindow.__init__(
+            self, parent=parent, pos=(1, 1), size=(50, 17), title='Main Window',
+            layout=win_layout)
+        self.setWindowFlag(0x0)
+
+        main_button = TermTk.TTkButton(text='main test button', border=True)
+        self._main_button = main_button
+        win_layout.addWidget(main_button, 0, 0)
+
+        new_win_button = TermTk.TTkButton(
+            text='create new listener window', border=True)
+        new_win_button.clicked.connect(
+            lambda: create_show_event_window(parent, main_button.clicked))
+        win_layout.addWidget(new_win_button, 2, 0)
+
+        slot_info = TermTk.TTkLabel(text='')
+        self._slot_info = slot_info
+        win_layout.addWidget(slot_info, 4, 0)
+
+        quit_button = TermTk.TTkButton(text='quit', border=True)
+        quit_button.clicked.connect(parent.quit)
+        win_layout.addWidget(quit_button, 6, 0)
+
+        self._info_timer = TermTk.TTkTimer()
+        self._info_timer.timeout.connect(self.show_info)
+        self._info_timer.start(timer_delay)
+
+        create_show_event_window(parent, main_button.clicked)
+
+    def show_info(self):
+        len_slots = len(self._main_button.clicked._connected_slots)
+        self._slot_info.setText(f"Main button has {len_slots} slots/listeners ")
+        self._info_timer.start(self._timer_delay)
+
+
+def create_show_event_window(parent, event):
+    win = ShowEventWindow(parent, event)
+    win.setFocus()
+
+def main():
+    '''show main window and start event loop.'''
+    root = TermTk.TTk()
+    TermTk.TTkLog.use_default_file_logging()
+
+    MainWindow(root, 0.5)
+
+    root.mainloop()
+
+
+if __name__ == '__main__':
+    main()
+
+# EOF


### PR DESCRIPTION
# (Signal-)slots with weak references

Subtitle: _Tired of slot-bookkeeping?_

## Facts
1. Currently **all** signals (i.e. instances of  the class `_pyTTkSignal_obj`) are saved inside a list in the class variable `_pyTTkSignal_obj._signals`
2. Many widgets create signals, e.g. `TTkWindow` and its buttons (close, minimize, etc.)
3. Every signal manages a list of connected slots/listeners in the variable `_connected_slots`

## Consequence
Even closed windows cannot be garbage collected because via the signal list, and the connected slots all the buttons are "reachable" and the buttons have links to their window and hence the windows are reachable.

## Solutions
There are many many ways to solve this problem. In the PR I tried one (in my opinion a lazy and elegant one).

There is a `WeakrefSlot` class. Instances of this class behave (transparently) like "slots", i.e. they are callable. The "only" difference to a "normal" slot is, that the target-function/listener is saved via a `weakref.ref` or `weakref.WeakMethod`. Hence the `WeakrefSlot` instances do **not** prevent the garbage collection.

Dead `WeakrefSlot` instances (i.e. `WeakrefSlot` where the target-function is not reachable anymore because it was garbage collected) are cleaned up lazily and automatically in the `emit` method.

I've attached a nice test `tests/test.ui.024.weakslots.py`:
[weakslots.webm](https://user-images.githubusercontent.com/7441996/210012810-d111d134-0cc6-4e04-9314-f69a0a031323.webm)

## Some questions remain
1. Is it necessary to save all signals in a **global** list? [If it's needed for pyodine, then perhaps its better to only save it if pyodine is used]
2. `WeakrefSlot` can only be used if the target-function/slot is "weakly referable", i.e. it allows for a `__weakref__` attribute. Does `TermTk.TTkWidget` and subclasses want to support this? (see Attention)

## Attention
The `tests/test.ui.024.weakslots.py` code uses a current "bug" in TermTk. All the Widgets have a `__dict__`  (as discussed in an other PR). That's the reason why e.g. `ShowEventWindow.show_event` or `TTkWindow.close` are "weakly referable". Without `__weakref__` attribute there is no chance to get a weakref for such objects.

> Without a `__weakref__` variable for each instance, classes defining `__slots__` do not support [weak references](https://docs.python.org/3/library/weakref.html#module-weakref) to its instances. If weak reference support is needed, then add `__weakref__` to the sequence of strings in the `__slots__` declaration.
https://docs.python.org/3/reference/datamodel.html#notes-on-using-slots

