### PR TITLE
Added Fillcolor in the window widget

### DIFF
--- a/TermTk/TTkWidgets/TTkPickers/colorpicker.py
+++ b/TermTk/TTkWidgets/TTkPickers/colorpicker.py
@@ -326,12 +326,15 @@ class TTkColorDialogPicker(TTkWindow):
 
     classStyle = {
                 'default':     {'color': TTkColor.RST,
+                                'fillColor':TTkColor.RST,
                                 'borderColor': TTkColor.RST,
                                 'titleColor': TTkColor.fg("#dddddd")+TTkColor.bg("#222222")},
                 'disabled':    {'color': TTkColor.fg('#888888'),
+                                'fillColor':TTkColor.RST,
                                 'borderColor':TTkColor.fg('#888888'),
                                 'titleColor': TTkColor.fg('#888888')},
                 'focus':       {'color': TTkColor.fg("#dddd88")+TTkColor.bg("#000044")+TTkColor.BOLD,
+                                'fillColor':TTkColor.RST,
                                 'borderColor': TTkColor.fg("#ffff55"),
                                 'titleColor': TTkColor.fg("#ffffdd")+TTkColor.bg("#222222")},
             }

--- a/TermTk/TTkWidgets/window.py
+++ b/TermTk/TTkWidgets/window.py
@@ -52,10 +52,13 @@ class TTkWindow(TTkResizableFrame):
 
     classStyle = {
                 'default':     {'color': TTkColor.RST,
+                                'fillColor':TTkColor.RST,
                                 'borderColor': TTkColor.RST},
                 'disabled':    {'color': TTkColor.fg('#888888'),
+                                'fillColor':TTkColor.RST,
                                 'borderColor':TTkColor.fg('#888888')},
                 'focus':       {'color': TTkColor.fg("#dddd88")+TTkColor.bg("#000044")+TTkColor.BOLD,
+                                'fillColor':TTkColor.RST,
                                 'borderColor': TTkColor.fg("#ffff55")}
             }
 
@@ -204,8 +207,11 @@ class TTkWindow(TTkResizableFrame):
     def paintEvent(self, canvas):
         style = self.currentStyle()
         color = style['color']
+        fillColor = style['fillColor']
         borderColor = style['borderColor']
 
+        if fillColor != TTkColor.RST:
+            canvas.fill(color=fillColor)
         canvas.drawText(pos=(2,1),text=self._title, color=color)
         canvas.drawGrid(
                     color=borderColor,

--- a/tests/t.ui/test.ui.033.styles.01.windows.py
+++ b/tests/t.ui/test.ui.033.styles.01.windows.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+# MIT License
+#
+# Copyright (c) 2024 Eugenio Parodi <ceccopierangiolieugenio AT googlemail DOT com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import sys
+
+sys.path.append(os.path.join(sys.path[0],'../..'))
+import TermTk as ttk
+
+root = ttk.TTk(title="pyTermTk Styles Demo")
+
+win = ttk.TTkWindow(parent=root, size=(50,10), title=" Test Window ")
+win.mergeStyle(
+        {'default':{
+                    'color':ttk.TTkColor.FG_RED+ttk.TTkColor.BG_GREEN,
+                    'fillColor':ttk.TTkColor.BG_BLACK,
+                    'borderColor':ttk.TTkColor.MAGENTA},
+         'focus':{
+                    'color':ttk.TTkColor.BG_RED+ttk.TTkColor.FG_GREEN,
+                    'fillColor':ttk.TTkColor.BG_BLUE,
+                    'borderColor':ttk.TTkColor.CYAN}})
+
+root.mainloop()


### PR DESCRIPTION
From:
https://github.com/ceccopierangiolieugenio/pyTermTk/discussions/297#discussioncomment-11579114

```python
root = ttk.TTk(title="pyTermTk Styles Demo")

win = ttk.TTkWindow(parent=root, size=(50,10), title=" Test Window ")
win.mergeStyle(
        {'default':{
                    'color':ttk.TTkColor.FG_RED+ttk.TTkColor.BG_GREEN,
                    'fillColor':ttk.TTkColor.BG_BLACK,
                    'borderColor':ttk.TTkColor.MAGENTA},
         'focus':{
                    'color':ttk.TTkColor.BG_RED+ttk.TTkColor.FG_GREEN,
                    'fillColor':ttk.TTkColor.BG_BLUE,
                    'borderColor':ttk.TTkColor.CYAN}})

root.mainloop()
```


https://github.com/user-attachments/assets/389e4708-83de-43ea-a13b-9431bfcd93ec