### PR TITLE
add multiply to ttkspacer

### DIFF
--- a/TermTk/TTkWidgets/spacer.py
+++ b/TermTk/TTkWidgets/spacer.py
@@ -29,3 +29,10 @@ class TTkSpacer(TTkWidget):
     __slots__ = ()
     def __init__(self, **kwargs) -> None:
         TTkWidget.__init__(self, **kwargs)
+
+    def __mul__(self, num:int):
+        if not isinstance(num, int):
+            raise ValueError(f"Expected int but got {type(num)}")
+        return [TTkSpacer() for _ in range(num)]
+
+        


### PR DESCRIPTION
- Override the multiplication dunder for ttkspacer to support creating multiple spacers at a time.

for example:
```python
row_2.addWidgets([ttk.TTkButton(text="Submit"), *ttk.TTkSpacer() * 3])
```

I want to add a test but I cannot figure out the naming scheme of the t.ui tests. 

So Here is the test:
```python
import TermTk as ttk

root = ttk.TTk(layout=ttk.TTkVBoxLayout())
frame_1 = ttk.TTkFrame(title="Without Spacer", border=True, layout=ttk.TTkHBoxLayout(), parent=root)
frame_1.layout().addWidgets([ttk.TTkButton(text="Button 1")])

frame_2 = ttk.TTkFrame(title="With 1 Spacer", border=True, layout=ttk.TTkHBoxLayout(), parent=root)
frame_2.layout().addWidgets([ttk.TTkButton(text="Button 2"), ttk.TTkSpacer()])

frame_3 = ttk.TTkFrame(title="With multiple Spacer", border=True, layout=ttk.TTkHBoxLayout(), parent=root)
frame_3.layout().addWidgets([ttk.TTkButton(text="Button 3"), *ttk.TTkSpacer() * 100])

root.mainloop()
```
