### PR TITLE
feat(log): setExceptionHandler() print traceback to stdout

### DIFF
--- a/libs/pyTermTk/TermTk/TTkCore/TTkTerm/term_base.py
+++ b/libs/pyTermTk/TermTk/TTkCore/TTkTerm/term_base.py
@@ -148,6 +148,12 @@ class TTkTermBase():
         else:
             return f'\033]0;{tt}{txt}\a'
 
+    @staticmethod
+    def printTraceback(exc):
+        from traceback import format_exc
+        print(TTkTermBase.NORMAL_SCREEN + "\n\nTTk Termination!\n\n" + str(exc) + format_exc(), flush=True)
+        print(TTkTermBase.escTitle("TTk Termination!"))
+
     # NOTE: Due to "I have no idea how to do it in a better way",
     # those methods are supposed to be overwritten with the
     # compatible one in "term_unix.py" or "term_pyodide.py"

--- a/libs/pyTermTk/TermTk/TTkCore/ttk.py
+++ b/libs/pyTermTk/TermTk/TTkCore/ttk.py
@@ -97,6 +97,9 @@ class TTk(TTkContainer):
         if ('TERMTK_FILE_LOG' in os.environ and (_logFile := os.environ['TERMTK_FILE_LOG'])):
             TTkLog.use_default_file_logging(_logFile)
 
+        TTkLog.setExceptionHandler()  # _main_exception
+        threading.excepthook = TTkLog._thread_exception
+
         self._timer = None
         self._title = title
         self._sigmask = sigmask


### PR DESCRIPTION
These changes to error logging are only relevant when encountering an exception so serious that execution cannot continue.

+ Added: Print a full stack traceback to the normal screen on exception
+ Fixed: Avoid console input lockup and reduce corrupted output when crashing

This new `setExceptionHandler()` method has an optional `hook` argument to set a custom function to run when the log renderer has crashed...

- By default it switches to the normal screen and prints a full stack traceback to the console's standard output, which is needed because Python cannot properly write an error message onto the alternate screen within the program without corrupting it.
- If set to a function then you could make a dialog overlay or widget to display the details about the crash and you might decide to ignore certain errors by ending the exception gracefully instead of bailing out and junking the console session.

It makes development and testing much easier and faster, especially with larger applications when pushing the boundaries of what the library can do, where crashing in a thread causes the default Python handler to panic the host terminal unless the `NORMAL_SCREEN` escape sequence is sent before attempting to print a trace to `stdout`, which is what this PR does.