### PR TITLE
fix(textdocument): TypeError exception in characterCount() method

### DIFF
--- a/libs/pyTermTk/TermTk/TTkGui/textdocument.py
+++ b/libs/pyTermTk/TermTk/TTkGui/textdocument.py
@@ -236,7 +236,7 @@ class TTkTextDocument():
         return len(self._dataLines)
 
     def characterCount(self):
-        return sum([len[x] for x in self._dataLines])+self.lineCount()
+        return sum([len(x) for x in self._dataLines])+self.lineCount()
 
     def clear(self):
         self.setText(self._default_init_text)


### PR DESCRIPTION
Resolves `TypeError: 'builtin_function_or_method' object is not subscriptable` - len()

There is no way to avoid encountering this exception, it always happens everytime.

Reproducer:
```
text_edit = ttk.TTkTextEdit()
char_count = text_edit.document().characterCount()
```

This is more like the size of PR that I like to make when there's a stack trace to find the actual cause of error with ease :)