### PR TITLE
fix(libs): update sys.path to run test apps directly from the repo

### DIFF
--- a/apps/dumbPaintTool/main.py
+++ b/apps/dumbPaintTool/main.py
@@ -22,7 +22,7 @@
 # SOFTWARE.
 
 import sys,os
-sys.path.append(os.path.join(sys.path[0],'../../'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 
 from dumbPaintTool.app import main
 

--- a/apps/perspectivator/perspectivator.pil.py
+++ b/apps/perspectivator/perspectivator.pil.py
@@ -33,7 +33,7 @@ import numpy as np,array
 
 from PIL import Image, ImageDraw, ImageFilter, ImageChops, ImageOps
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 
 import TermTk as ttk
 

--- a/demo/games/breakout/main.py
+++ b/demo/games/breakout/main.py
@@ -25,7 +25,7 @@
 import sys, os, math
 from dataclasses import dataclass
 
-sys.path.append(os.path.join(sys.path[0],'../../..'))
+sys.path.append(os.path.join(sys.path[0],'../../../libs/pyTermTk'))
 import TermTk as ttk
 
 @dataclass

--- a/demo/games/breakoutrl/main.py
+++ b/demo/games/breakoutrl/main.py
@@ -25,7 +25,7 @@
 import sys, os
 from random import randint
 
-sys.path.append(os.path.join(sys.path[0],'../../..'))
+sys.path.append(os.path.join(sys.path[0],'../../../libs/pyTermTk'))
 import TermTk as ttk
 
 from bolib import *

--- a/demo/paint.py
+++ b/demo/paint.py
@@ -27,7 +27,7 @@ import os
 import sys
 import time
 
-sys.path.append(os.path.join(sys.path[0],'..'))
+sys.path.append(os.path.join(sys.path[0],'../libs/pyTermTk'))
 from TermTk import TTk, TTkGridLayout, TTkK, TTkWidget, TTkWindow, TTkColor, TTkRadioButton, TTkSpacer
 
 parser = argparse.ArgumentParser()

--- a/demo/showcase/animation.01.py
+++ b/demo/showcase/animation.01.py
@@ -27,7 +27,7 @@ import sys
 import random
 import argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 sys.path.append(os.path.join(sys.path[0],'..'))

--- a/demo/showcase/apptemplate.py
+++ b/demo/showcase/apptemplate.py
@@ -25,7 +25,7 @@
 import sys, os, argparse
 from random import randint
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 

--- a/demo/showcase/colorpicker.py
+++ b/demo/showcase/colorpicker.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 

--- a/demo/showcase/dndtabs.py
+++ b/demo/showcase/dndtabs.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 def demoDnDTabs(root=None, border=True):

--- a/demo/showcase/dragndrop.py
+++ b/demo/showcase/dragndrop.py
@@ -27,7 +27,7 @@ import sys
 import random
 import argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 class DragThing(ttk.TTkFrame):

--- a/demo/showcase/fancytable.py
+++ b/demo/showcase/fancytable.py
@@ -25,7 +25,7 @@
 import sys, os
 import random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 sys.path.append(os.path.join(sys.path[0],'..'))

--- a/demo/showcase/fancytree.py
+++ b/demo/showcase/fancytree.py
@@ -30,7 +30,7 @@ import sys
 import random
 import argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 sys.path.append(os.path.join(sys.path[0],'..'))

--- a/demo/showcase/formwidgets01.py
+++ b/demo/showcase/formwidgets01.py
@@ -25,7 +25,7 @@
 import sys, os, argparse
 import random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 sys.path.append(os.path.join(sys.path[0],'..'))

--- a/demo/showcase/formwidgets02.py
+++ b/demo/showcase/formwidgets02.py
@@ -25,7 +25,7 @@
 import sys, os, argparse
 import random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 sys.path.append(os.path.join(sys.path[0],'..'))

--- a/demo/showcase/graph.py
+++ b/demo/showcase/graph.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 class graphTimerEvent():

--- a/demo/showcase/layout_basic.py
+++ b/demo/showcase/layout_basic.py
@@ -24,7 +24,7 @@
 
 import sys, os
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 

--- a/demo/showcase/layout_nested.py
+++ b/demo/showcase/layout_nested.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 

--- a/demo/showcase/layout_span.py
+++ b/demo/showcase/layout_span.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 

--- a/demo/showcase/list.py
+++ b/demo/showcase/list.py
@@ -25,7 +25,7 @@
 import sys, os, argparse, math, random
 
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 sys.path.append(os.path.join(sys.path[0],'..'))

--- a/demo/showcase/menubar.py
+++ b/demo/showcase/menubar.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 

--- a/demo/showcase/messagebox.py
+++ b/demo/showcase/messagebox.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 

--- a/demo/showcase/scrollarea01.py
+++ b/demo/showcase/scrollarea01.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 class graphTimerEvent():

--- a/demo/showcase/scrollarea02.py
+++ b/demo/showcase/scrollarea02.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 def demoScrollArea02(root = None):

--- a/demo/showcase/sigmask.py
+++ b/demo/showcase/sigmask.py
@@ -26,7 +26,7 @@ import os
 import sys
 import argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 def demoSigmask(root=None):

--- a/demo/showcase/splitter.py
+++ b/demo/showcase/splitter.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 

--- a/demo/showcase/splitter2.py
+++ b/demo/showcase/splitter2.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 

--- a/demo/showcase/splitter3.py
+++ b/demo/showcase/splitter3.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 

--- a/demo/showcase/splitter4.py
+++ b/demo/showcase/splitter4.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 

--- a/demo/showcase/tab.py
+++ b/demo/showcase/tab.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 def demoTab(root=None, border=True):

--- a/demo/showcase/table.py
+++ b/demo/showcase/table.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 sys.path.append(os.path.join(sys.path[0],'..'))

--- a/demo/showcase/textedit.py
+++ b/demo/showcase/textedit.py
@@ -27,7 +27,7 @@ import sys
 import random
 import argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk/'))
 import TermTk as ttk
 
 sys.path.append(os.path.join(sys.path[0],'..'))

--- a/demo/showcase/textpicker.py
+++ b/demo/showcase/textpicker.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 def demoTextPicker(root=None):

--- a/demo/showcase/tree.py
+++ b/demo/showcase/tree.py
@@ -30,7 +30,7 @@ import sys
 import random
 import argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 sys.path.append(os.path.join(sys.path[0],'..'))

--- a/demo/showcase/windows.py
+++ b/demo/showcase/windows.py
@@ -25,7 +25,7 @@
 import sys, os
 
 sys.path.append(os.path.join(sys.path[0],'../../tmp'))
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 

--- a/demo/showcase/windowsflags.py
+++ b/demo/showcase/windowsflags.py
@@ -25,7 +25,7 @@
 import sys, os
 
 sys.path.append(os.path.join(sys.path[0],'../../tmp'))
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 # Testing Window with a checkbox to enable/disable any control button

--- a/multiplexers/basic/main.py
+++ b/multiplexers/basic/main.py
@@ -29,7 +29,7 @@ import threading
 import argparse
 from select import select
 
-sys.path.append(os.path.join(sys.path[0],'..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 parser = argparse.ArgumentParser()

--- a/multiplexers/workbench/main.py
+++ b/multiplexers/workbench/main.py
@@ -30,7 +30,7 @@ import argparse
 from select import select
 
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 from TermTk.TTkCore.canvas import TTkCanvas

--- a/multiplexers/workbench/wblib/colors.py
+++ b/multiplexers/workbench/wblib/colors.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # MIT License
 #
 # Copyright (c) 2023 Eugenio Parodi <ceccopierangiolieugenio AT googlemail DOT com>
@@ -25,7 +23,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
 import TermTk as ttk
 
 # Colors:

--- a/tests/stress/01.many.widgets.py
+++ b/tests/stress/01.many.widgets.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 
 import TermTk as ttk
 

--- a/tests/stress/02.many.tree.nodes.py
+++ b/tests/stress/02.many.tree.nodes.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 
 import TermTk as ttk
 

--- a/tests/stress/03.parallax.01.py
+++ b/tests/stress/03.parallax.01.py
@@ -25,7 +25,7 @@
 import sys, os
 import time, math
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 class Parallax(ttk.TTk):

--- a/tests/stress/03.parallax.02.py
+++ b/tests/stress/03.parallax.02.py
@@ -25,7 +25,7 @@
 import sys, os
 import time, math
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 class Parallax(ttk.TTk):

--- a/tests/stress/03.parallax.03.py
+++ b/tests/stress/03.parallax.03.py
@@ -25,7 +25,7 @@
 import sys, os
 import time, math
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 HouseBG_1_1 = ttk.TTkUtil.base64_deflate_2_obj(

--- a/tests/t.draw/test.draw.001.py
+++ b/tests/t.draw/test.draw.001.py
@@ -26,7 +26,7 @@ import sys, os
 import logging
 import time
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 from TermTk import TTkLog, TTkTerm
 
 def message_handler(mode, context, message):
@@ -43,8 +43,8 @@ logging.basicConfig(level=logging.DEBUG,
                     format='%(levelname)s:(%(threadName)-9s) %(message)s',)
 TTkLog.installMessageHandler(message_handler)
 
-TTkTerm.init(mouse=False)
-
+TTkTerm.init()
+TTkTerm.setMouse(mouse=False)
 TTkTerm.push(
         TTkTerm.Cursor.moveTo(2,4) +
         "Test Text 3"

--- a/tests/t.draw/test.draw.002.py
+++ b/tests/t.draw/test.draw.002.py
@@ -26,18 +26,19 @@ import sys, os
 import logging
 import time
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 from TermTk import TTkLog
 from TermTk.TTkCore import TTkColor
 from TermTk.TTkCore import TTkHelper, TTkTerm
 
 TTkLog.use_default_file_logging()
 
-TTkTerm.init(mouse=False)
+TTkTerm.init()
+TTkTerm.setMouse(mouse=False)
 TTkLog.info("Starting")
 TTkTerm.push(
         TTkTerm.Cursor.moveTo(2,4) +
-        TTkColor.fg("#ff0000") +
+        str(TTkColor.fg("#ff0000")) +
         "Test Text 3"
     )
 time.sleep(1)
@@ -45,14 +46,14 @@ TTkLog.info("next : 2")
 
 TTkTerm.push(
         TTkTerm.Cursor.moveDown(1) + TTkTerm.Cursor.moveLeft(3) +
-        TTkColor.bg("#550088") +
+        str(TTkColor.bg("#550088")) +
         "Test Text 2"
     )
 time.sleep(1)
 TTkLog.info("next : 1")
 
 TTkTerm.push(
-        TTkTerm.Cursor.moveDown(1) + TTkTerm.Cursor.moveLeft(3) +
+        TTkTerm.Cursor.moveDown(1) + TTkTerm.Cursor.moveLeft(3) +  # FIXME
         TTkColor.fg("#00ff00") +
         TTkColor.bg("#555500") +
         "Test Text 1"

--- a/tests/t.draw/test.draw.003.py
+++ b/tests/t.draw/test.draw.003.py
@@ -26,7 +26,7 @@ import sys, os
 import logging
 import time
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 from TermTk import TTkLog
 from TermTk.TTkCore import TTkColor
 from TermTk.TTkCore import TTkHelper

--- a/tests/t.draw/test.draw.004.py
+++ b/tests/t.draw/test.draw.004.py
@@ -26,7 +26,7 @@ import sys, os
 import logging
 import time
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 from TermTk import TTkLog
 from TermTk.TTkCore import TTkColor
 from TermTk.TTkCore import TTkHelper

--- a/tests/t.draw/test.draw.005.py
+++ b/tests/t.draw/test.draw.005.py
@@ -26,7 +26,7 @@ import sys, os
 import logging
 import time
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 from TermTk import TTkLog
 from TermTk.TTkCore import TTkColor
 from TermTk.TTkCore import TTkHelper

--- a/tests/t.draw/test.draw.006.py
+++ b/tests/t.draw/test.draw.006.py
@@ -26,7 +26,7 @@ import sys, os
 import logging
 import time
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 from TermTk import TTkLog
 from TermTk.TTkCore import TTkColor
 from TermTk.TTkCore import TTkHelper

--- a/tests/t.draw/test.draw.007.py
+++ b/tests/t.draw/test.draw.007.py
@@ -26,7 +26,7 @@ import sys, os
 import logging
 import time
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 from TermTk import TTkLog
 from TermTk.TTkCore import TTkColor
 from TermTk.TTkCore import TTkHelper

--- a/tests/t.draw/test.draw.008.align.py
+++ b/tests/t.draw/test.draw.008.align.py
@@ -26,6 +26,9 @@
 # https://github.com/ceccopierangiolieugenio/pyTermTk/pull/70
 # from luchr https://github.com/luchr
 
+import sys, os
+
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk
 
 root = TermTk.TTk()  # in order to have TTkCfg.theme

--- a/tests/t.draw/test.draw.009.colorMix.py
+++ b/tests/t.draw/test.draw.009.colorMix.py
@@ -24,7 +24,7 @@
 
 import sys, os
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 def testColor(prefix:str,c1:ttk.TTkColor, c2:ttk.TTkColor):

--- a/tests/t.generic/test.ansi.001.py
+++ b/tests/t.generic/test.ansi.001.py
@@ -26,7 +26,7 @@ import sys, os
 import logging
 import time
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 from TermTk import TTkLog
 from TermTk.TTkCore import TTkColor
 from TermTk.TTkCore import TTkHelper

--- a/tests/t.generic/test.classes.001.slots.py
+++ b/tests/t.generic/test.classes.001.slots.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 # vim:ts=4:sw=4:fdm=indent:cc=79:
 
+import os, sys
+
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk
 
 def find_classes(cand_dict):

--- a/tests/t.input/test.input.py
+++ b/tests/t.input/test.input.py
@@ -25,7 +25,7 @@
 import sys, os
 import logging
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 from TermTk import TTkLog, TTkK, TTkTerm, TTkInput
 
 def message_handler(mode, context, message):

--- a/tests/t.input/test.input.win.02.py
+++ b/tests/t.input/test.input.win.02.py
@@ -24,7 +24,7 @@ import sys,os
 
 from ctypes import Structure, Union, byref, wintypes, windll
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 
 from TermTk.TTkCore.constant import TTkK
 from TermTk.TTkCore.TTkTerm.inputmouse import TTkMouseEvent

--- a/tests/t.pty/test.pty.001.py
+++ b/tests/t.pty/test.pty.001.py
@@ -40,7 +40,7 @@ import threading
 from select import select
 
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 class thread(threading.Thread):

--- a/tests/t.pty/test.pty.002.py
+++ b/tests/t.pty/test.pty.002.py
@@ -40,7 +40,7 @@ import threading
 from select import select
 
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 class TermThread(threading.Thread):

--- a/tests/t.pty/test.pty.003.py
+++ b/tests/t.pty/test.pty.003.py
@@ -40,7 +40,7 @@ import threading
 from select import select
 
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 class TermThread(threading.Thread):

--- a/tests/t.pty/test.pty.004.openpty.01.py
+++ b/tests/t.pty/test.pty.004.openpty.01.py
@@ -43,7 +43,7 @@ import threading
 from select import select
 
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 class TermThread(threading.Thread):

--- a/tests/t.pty/test.pty.004.openpty.02.py
+++ b/tests/t.pty/test.pty.004.openpty.02.py
@@ -43,7 +43,7 @@ import threading
 from select import select
 
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 class TermThread(threading.Thread):

--- a/tests/t.pty/test.pty.005.fork.py
+++ b/tests/t.pty/test.pty.005.fork.py
@@ -44,7 +44,7 @@ import threading
 from select import select
 
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 class TermThread(threading.Thread):

--- a/tests/t.pty/test.pty.006.terminal.01.py
+++ b/tests/t.pty/test.pty.006.terminal.01.py
@@ -44,7 +44,7 @@ import threading
 from select import select
 
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 ttk.TTkLog.use_default_file_logging()

--- a/tests/t.pty/test.pty.006.terminal.02.py
+++ b/tests/t.pty/test.pty.006.terminal.02.py
@@ -44,7 +44,7 @@ import threading
 import argparse
 from select import select
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 parser = argparse.ArgumentParser()

--- a/tests/t.ui/test.ui.001.frame.01.py
+++ b/tests/t.ui/test.ui.001.frame.01.py
@@ -24,7 +24,7 @@
 
 import sys, os
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 ttk.TTkLog.use_default_file_logging()

--- a/tests/t.ui/test.ui.001.window.01.py
+++ b/tests/t.ui/test.ui.001.window.01.py
@@ -24,7 +24,7 @@
 
 import sys, os
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 ttk.TTkLog.use_default_file_logging()

--- a/tests/t.ui/test.ui.002.py
+++ b/tests/t.ui/test.ui.002.py
@@ -24,7 +24,7 @@
 
 import sys, os
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 ttk.TTkLog.use_default_file_logging()

--- a/tests/t.ui/test.ui.003.layout.position.py
+++ b/tests/t.ui/test.ui.003.layout.position.py
@@ -24,7 +24,7 @@
 
 import sys, os
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 ttk.TTkLog.use_default_file_logging()

--- a/tests/t.ui/test.ui.003.layout.py
+++ b/tests/t.ui/test.ui.003.layout.py
@@ -24,7 +24,7 @@
 
 import sys, os
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 ttk.TTkLog.use_default_file_logging()

--- a/tests/t.ui/test.ui.003.layout.span.py
+++ b/tests/t.ui/test.ui.003.layout.span.py
@@ -24,7 +24,7 @@
 
 import sys, os
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 

--- a/tests/t.ui/test.ui.004.windows.py
+++ b/tests/t.ui/test.ui.004.windows.py
@@ -24,7 +24,7 @@
 
 import sys, os
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 ttk.TTkLog.use_default_file_logging()

--- a/tests/t.ui/test.ui.005.labels.py
+++ b/tests/t.ui/test.ui.005.labels.py
@@ -24,7 +24,7 @@
 
 import sys, os
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 ttk.TTkLog.use_default_file_logging()

--- a/tests/t.ui/test.ui.006.scroll.01.py
+++ b/tests/t.ui/test.ui.006.scroll.01.py
@@ -24,7 +24,7 @@
 
 import sys, os
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 ttk.TTkLog.use_default_file_logging()

--- a/tests/t.ui/test.ui.006.scroll.02.tryLoop.py
+++ b/tests/t.ui/test.ui.006.scroll.02.tryLoop.py
@@ -24,7 +24,7 @@
 
 import sys, os
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 root = ttk.TTk()

--- a/tests/t.ui/test.ui.007.events.py
+++ b/tests/t.ui/test.ui.007.events.py
@@ -24,7 +24,7 @@
 
 import sys, os
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 ttk.TTkLog.use_default_file_logging()

--- a/tests/t.ui/test.ui.008.fancy.table.py
+++ b/tests/t.ui/test.ui.008.fancy.table.py
@@ -25,7 +25,7 @@
 import sys, os
 import random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 words = ["Lorem", "ipsum", "dolor", "sit", "amet,", "consectetur", "adipiscing", "elit,", "sed", "do", "eiusmod", "tempor", "incididunt", "ut", "labore", "et", "dolore", "magna", "aliqua.", "Ut", "enim", "ad", "minim", "veniam,", "quis", "nostrud", "exercitation", "ullamco", "laboris", "nisi", "ut", "aliquip", "ex", "ea", "commodo", "consequat.", "Duis", "aute", "irure", "dolor", "in", "reprehenderit", "in", "voluptate", "velit", "esse", "cillum", "dolore", "eu", "fugiat", "nulla", "pariatur.", "Excepteur", "sint", "occaecat", "cupidatat", "non", "proident,", "sunt", "in", "culpa", "qui", "officia", "deserunt", "mollit", "anim", "id", "est", "laborum."]

--- a/tests/t.ui/test.ui.009.widgets.form.py
+++ b/tests/t.ui/test.ui.009.widgets.form.py
@@ -25,7 +25,7 @@
 import sys, os
 import random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 words = ["Lorem", "ipsum", "dolor", "sit", "amet,", "consectetur", "adipiscing", "elit,", "sed", "do", "eiusmod", "tempor", "incididunt", "ut", "labore", "et", "dolore", "magna", "aliqua.", "Ut", "enim", "ad", "minim", "veniam,", "quis", "nostrud", "exercitation", "ullamco", "laboris", "nisi", "ut", "aliquip", "ex", "ea", "commodo", "consequat.", "Duis", "aute", "irure", "dolor", "in", "reprehenderit", "in", "voluptate", "velit", "esse", "cillum", "dolore", "eu", "fugiat", "nulla", "pariatur.", "Excepteur", "sint", "occaecat", "cupidatat", "non", "proident,", "sunt", "in", "culpa", "qui", "officia", "deserunt", "mollit", "anim", "id", "est", "laborum."]

--- a/tests/t.ui/test.ui.010.splitter.01.py
+++ b/tests/t.ui/test.ui.010.splitter.01.py
@@ -24,7 +24,7 @@
 
 import sys, os
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 ttk.TTkLog.use_default_file_logging()

--- a/tests/t.ui/test.ui.010.splitter.02.py
+++ b/tests/t.ui/test.ui.010.splitter.02.py
@@ -24,7 +24,7 @@
 
 import sys, os
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 ttk.TTkLog.use_default_file_logging()

--- a/tests/t.ui/test.ui.010.splitter.03.py
+++ b/tests/t.ui/test.ui.010.splitter.03.py
@@ -24,7 +24,7 @@
 
 import sys, os
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 ttk.TTkLog.use_default_file_logging()

--- a/tests/t.ui/test.ui.011.fancy.tree.py
+++ b/tests/t.ui/test.ui.011.fancy.tree.py
@@ -28,7 +28,7 @@
 import os
 import sys
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 ttk.TTkLog.use_default_file_logging()

--- a/tests/t.ui/test.ui.011.tree.01.py
+++ b/tests/t.ui/test.ui.011.tree.01.py
@@ -29,7 +29,7 @@ import os
 import sys
 import argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 ttk.TTkLog.use_default_file_logging()

--- a/tests/t.ui/test.ui.013.graph.py
+++ b/tests/t.ui/test.ui.013.graph.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 def demoGraph(root= None):

--- a/tests/t.ui/test.ui.014.list.01.py
+++ b/tests/t.ui/test.ui.014.list.01.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 words = ["Lorem", "ipsum", "dolor", "sit", "amet,", "consectetur", "adipiscing", "elit,", "sed", "do", "eiusmod", "tempor", "incididunt", "ut", "labore", "et", "dolore", "magna", "aliqua.", "Ut", "enim", "ad", "minim", "veniam,", "quis", "nostrud", "exercitation", "ullamco", "laboris", "nisi", "ut", "aliquip", "ex", "ea", "commodo", "consequat.", "Duis", "aute", "irure", "dolor", "in", "reprehenderit", "in", "voluptate", "velit", "esse", "cillum", "dolore", "eu", "fugiat", "nulla", "pariatur.", "Excepteur", "sint", "occaecat", "cupidatat", "non", "proident,", "sunt", "in", "culpa", "qui", "officia", "deserunt", "mollit", "anim", "id", "est", "laborum."]

--- a/tests/t.ui/test.ui.014.list.02.py
+++ b/tests/t.ui/test.ui.014.list.02.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 words = ["Lorem", "ipsum", "dolor", "sit", "amet,", "consectetur", "adipiscing", "elit,", "sed", "do", "eiusmod", "tempor", "incididunt", "ut", "labore", "et", "dolore", "magna", "aliqua.", "Ut", "enim", "ad", "minim", "veniam,", "quis", "nostrud", "exercitation", "ullamco", "laboris", "nisi", "ut", "aliquip", "ex", "ea", "commodo", "consequat.", "Duis", "aute", "irure", "dolor", "in", "reprehenderit", "in", "voluptate", "velit", "esse", "cillum", "dolore", "eu", "fugiat", "nulla", "pariatur.", "Excepteur", "sint", "occaecat", "cupidatat", "non", "proident,", "sunt", "in", "culpa", "qui", "officia", "deserunt", "mollit", "anim", "id", "est", "laborum."]

--- a/tests/t.ui/test.ui.014.list.03.py
+++ b/tests/t.ui/test.ui.014.list.03.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 zc1 = chr(0x07a6) # Zero width chars oަ

--- a/tests/t.ui/test.ui.014.list.04.py
+++ b/tests/t.ui/test.ui.014.list.04.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 zc1 = chr(0x07a6) # Zero width chars oަ

--- a/tests/t.ui/test.ui.014.list.05.stress.py
+++ b/tests/t.ui/test.ui.014.list.05.stress.py
@@ -24,7 +24,7 @@
 
 import sys, os
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 root = ttk.TTk(title="pyTermTk List Demo", mouseTrack=True)

--- a/tests/t.ui/test.ui.015.scrollArea.01.py
+++ b/tests/t.ui/test.ui.015.scrollArea.01.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 def demoScrollArea(root= None):

--- a/tests/t.ui/test.ui.015.scrollArea.02.py
+++ b/tests/t.ui/test.ui.015.scrollArea.02.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 def demoScrollArea(root):

--- a/tests/t.ui/test.ui.015.scrollArea.03.py
+++ b/tests/t.ui/test.ui.015.scrollArea.03.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 def main():

--- a/tests/t.ui/test.ui.016.about.py
+++ b/tests/t.ui/test.ui.016.about.py
@@ -24,7 +24,7 @@
 
 import sys, os
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 ttk.TTkLog.use_default_file_logging()

--- a/tests/t.ui/test.ui.016.raster.py
+++ b/tests/t.ui/test.ui.016.raster.py
@@ -24,7 +24,7 @@
 
 import sys, os
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 ttk.TTkLog.use_default_file_logging()

--- a/tests/t.ui/test.ui.017.Drag.Drop.001.py
+++ b/tests/t.ui/test.ui.017.Drag.Drop.001.py
@@ -24,7 +24,7 @@
 
 import sys, os
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 class DragDrop(ttk.TTkFrame):

--- a/tests/t.ui/test.ui.018.TextEdit.01.Pygments.py
+++ b/tests/t.ui/test.ui.018.TextEdit.01.Pygments.py
@@ -31,7 +31,7 @@ from pygments import highlight
 from pygments.lexers import PythonLexer
 from pygments.formatters import TerminalFormatter, Terminal256Formatter, TerminalTrueColorFormatter
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 

--- a/tests/t.ui/test.ui.018.TextEdit.02.Pygments.py
+++ b/tests/t.ui/test.ui.018.TextEdit.02.Pygments.py
@@ -27,7 +27,7 @@ import sys
 import random
 import argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 def demoTextEdit(root, filenames):

--- a/tests/t.ui/test.ui.018.TextEdit.03.Pygments.py
+++ b/tests/t.ui/test.ui.018.TextEdit.03.Pygments.py
@@ -27,7 +27,7 @@ import sys
 import random
 import argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 def demoTextEdit(root, filename):

--- a/tests/t.ui/test.ui.018.TextEdit.04.ExtraSelect.py
+++ b/tests/t.ui/test.ui.018.TextEdit.04.ExtraSelect.py
@@ -27,7 +27,7 @@ import sys
 import random
 import argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 def demoTextEdit(root, filename):

--- a/tests/t.ui/test.ui.018.TextEdit.05.customRuler.py
+++ b/tests/t.ui/test.ui.018.TextEdit.05.customRuler.py
@@ -27,7 +27,7 @@ import sys
 import random
 import argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 def demoTextEdit(root, filename):

--- a/tests/t.ui/test.ui.019.multi.start.Ste.poc.py
+++ b/tests/t.ui/test.ui.019.multi.start.Ste.poc.py
@@ -24,7 +24,7 @@
 
 import sys, os
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 ttk.TTkLog.use_default_file_logging()

--- a/tests/t.ui/test.ui.020.TextEdit.01.UndoRedo.py
+++ b/tests/t.ui/test.ui.020.TextEdit.01.UndoRedo.py
@@ -27,7 +27,7 @@ import sys
 import random
 import argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 class superSimpleHorizontalLine(ttk.TTkWidget):

--- a/tests/t.ui/test.ui.020.TextEdit.02.UndoRedo.py
+++ b/tests/t.ui/test.ui.020.TextEdit.02.UndoRedo.py
@@ -27,7 +27,7 @@ import sys
 import random
 import argparse
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 class TestUndoRedo(ttk.TTkWidget):

--- a/tests/t.ui/test.ui.020.TextEdit.03.save.py
+++ b/tests/t.ui/test.ui.020.TextEdit.03.save.py
@@ -25,7 +25,7 @@
 import os
 import sys
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 def main():
@@ -38,7 +38,7 @@ def main():
     te1 = ttk.TTkTextEdit(parent=win1, readOnly=False, lineNumber=True)
     te2 = ttk.TTkTextEdit(parent=win2, readOnly=False, lineNumber=True)
 
-    with open(os.path.join(os.path.dirname(os.path.abspath(__file__)),'textedit.ANSI.txt')) as f:
+    with open(os.path.join(os.path.dirname(os.path.abspath(__file__)),'..','textedit.ANSI.txt')) as f:
         te1.append(f.read())
 
     btn1 = ttk.TTkButton(parent=root, pos=(0,0), border=True, text="Txt  to Te2")

--- a/tests/t.ui/test.ui.021.abstractscroll.01.py
+++ b/tests/t.ui/test.ui.021.abstractscroll.01.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 class ScrollAreaTest(ttk.TTkAbstractScrollArea):

--- a/tests/t.ui/test.ui.021.abstractscroll.02.py
+++ b/tests/t.ui/test.ui.021.abstractscroll.02.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 class ScrollAreaTest(ttk.TTkAbstractScrollArea):

--- a/tests/t.ui/test.ui.022.progressbar.py
+++ b/tests/t.ui/test.ui.022.progressbar.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 def main():

--- a/tests/t.ui/test.ui.023.01.colorLinearGradient.py
+++ b/tests/t.ui/test.ui.023.01.colorLinearGradient.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 from math import sin, cos
 

--- a/tests/t.ui/test.ui.023.02.colorLinearGradient.saveBuffer.py
+++ b/tests/t.ui/test.ui.023.02.colorLinearGradient.saveBuffer.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 from math import sin, cos
 

--- a/tests/t.ui/test.ui.024.canvas.boundaries.py
+++ b/tests/t.ui/test.ui.024.canvas.boundaries.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 from math import sin, cos
 

--- a/tests/t.ui/test.ui.025.layout.offset.py
+++ b/tests/t.ui/test.ui.025.layout.offset.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 from math import sin, cos
 

--- a/tests/t.ui/test.ui.026.toolTip.py
+++ b/tests/t.ui/test.ui.026.toolTip.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 root = ttk.TTk(title="pyTermTk Demo", mouseTrack=True)

--- a/tests/t.ui/test.ui.027.button.01.label.colors.py
+++ b/tests/t.ui/test.ui.027.button.01.label.colors.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 root = ttk.TTk(title="pyTermTk Demo", mouseTrack=True)

--- a/tests/t.ui/test.ui.027.button.02.sizes.py
+++ b/tests/t.ui/test.ui.027.button.02.sizes.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 root = ttk.TTk(title="pyTermTk Demo", mouseTrack=True)

--- a/tests/t.ui/test.ui.028.textPicker.01.py
+++ b/tests/t.ui/test.ui.028.textPicker.01.py
@@ -24,7 +24,7 @@
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 root = ttk.TTk(title="pyTermTk Demo", mouseTrack=True)

--- a/tests/t.ui/test.ui.029.image.tool.01.py
+++ b/tests/t.ui/test.ui.029.image.tool.01.py
@@ -28,7 +28,7 @@ import zlib, pickle, base64
 
 import sys, os, argparse, math, random
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 ttk.TTkTheme.loadTheme(ttk.TTkTheme.NERD)

--- a/tests/t.ui/test.ui.030.menu.01.py
+++ b/tests/t.ui/test.ui.030.menu.01.py
@@ -23,7 +23,7 @@
 # SOFTWARE.
 
 import sys, os
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 ttk.TTkTheme.loadTheme(ttk.TTkTheme.NERD)

--- a/tests/t.ui/test.ui.030.menu.02.bar.py
+++ b/tests/t.ui/test.ui.030.menu.02.bar.py
@@ -23,7 +23,7 @@
 # SOFTWARE.
 
 import sys, os
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 ttk.TTkTheme.loadTheme(ttk.TTkTheme.NERD)

--- a/tests/t.ui/test.ui.031.link.01.py
+++ b/tests/t.ui/test.ui.031.link.01.py
@@ -25,7 +25,7 @@
 import sys, os
 
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 class WidLink1(ttk.TTkWidget):

--- a/tests/t.ui/test.ui.031.link.02.py
+++ b/tests/t.ui/test.ui.031.link.02.py
@@ -25,7 +25,7 @@
 import sys, os
 
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 from TermTk import TTkColor,TTkString
 
 text = 'Link1abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ Test ░▒▓█▁▂▃▄▅▆▇█ Color\nLink1abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ Test ░▒▓█▁▂▃▄▅▆▇█ Color'

--- a/tests/t.ui/test.ui.031.shortcut.01.py
+++ b/tests/t.ui/test.ui.031.shortcut.01.py
@@ -23,7 +23,7 @@
 # SOFTWARE.
 
 import sys, os
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 class WindowThatHandleKeypress(ttk.TTkWindow):

--- a/tests/t.ui/test.ui.031.shortcut.02.menu.py
+++ b/tests/t.ui/test.ui.031.shortcut.02.menu.py
@@ -23,7 +23,7 @@
 # SOFTWARE.
 
 import sys, os
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 import TermTk as ttk
 
 class WindowThatHandleKeypress(ttk.TTkWindow):

--- a/tests/weakref/test.05.TermTk.01.py
+++ b/tests/weakref/test.05.TermTk.01.py
@@ -25,7 +25,7 @@
 import sys, os
 import gc, weakref, time
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 sys.path.append(os.path.join(sys.path[0],'.'))
 import TermTk as ttk
 

--- a/tests/weakref/test.05.TermTk.02.py
+++ b/tests/weakref/test.05.TermTk.02.py
@@ -25,7 +25,7 @@
 import sys, os
 import gc, weakref, time
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 sys.path.append(os.path.join(sys.path[0],'.'))
 import TermTk as ttk
 

--- a/tests/weakref/test.05.TermTk.03.signals.py
+++ b/tests/weakref/test.05.TermTk.03.signals.py
@@ -25,7 +25,7 @@
 import sys, os
 import gc, weakref, time
 
-sys.path.append(os.path.join(sys.path[0],'../..'))
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
 sys.path.append(os.path.join(sys.path[0],'.'))
 import TermTk as ttk
 


### PR DESCRIPTION
The repo has been reorganised at some point so the `TermTk` package couldn't be imported from a cloned repo because that is actually now in the `/libs/pyPermTk/` subfolder rather than the root directory.

As a result, not many of the examples that "[can be executed out of the box](https://ceccopierangiolieugenio.github.io/pyTermTk-Docs/info/installing.html#demos)" unless TermTk was installed with pip (and that's unlikely to be the case for someone who has cloned the git repo). There's no other reason the scripts set a path that I can see.