### PR TITLE
fix(colorpicker): IndexError on drag hue index out of range

### DIFF
--- a/libs/pyTermTk/TermTk/TTkWidgets/TTkPickers/colorpicker.py
+++ b/libs/pyTermTk/TermTk/TTkWidgets/TTkPickers/colorpicker.py
@@ -56,15 +56,15 @@ class _TTkHueCanvas(TTkWidget):
         self._selected = -1
         self.setFocusPolicy(TTkK.ClickFocus)
 
-
     def resizeEvent(self, width: int, height: int) -> None:
         self._selected = -1
 
     def mousePressEvent(self, evt:TTkMouseEvent) -> bool:
-        self._selected = evt.x
-        if evt.x < len(self._hueList):
-            self.colorPicked.emit(self._hueList[evt.x])
-        self.update()
+        x_pos = max(0, min(evt.x, self.width()-1))
+        if x_pos != self._selected:
+            self._selected = x_pos
+            self.colorPicked.emit(self._hueList[x_pos])
+            self.update()
         return True
 
     def mouseDragEvent(self, evt:TTkMouseEvent) -> bool:


### PR DESCRIPTION
+ Fixed: crash when dragging hue out of range
+ Added: constrain the selection to within the extents of the hue canvas

Also avoids repainting the color canvas unless the value actually changed as a result of the mouse event, since now if the mouse goes off either end then the selected value snaps, one time only, to either the minimum or maximum possible value in the range.

_To replicate crash, position the picker dialog over to the right of a maximized window and then drag the hue slider very far off to the left:_
```
Caught an exception: list index out of range <_io.TextIOWrapper name='<stderr>' mode='w' encoding='utf-8'>
Traceback (most recent call last):
  File "/home/user/Git/slook/pyTermTk/demo/showcase/colorpicker.py", line 85, in <module>
    main()
  File "/home/user/Git/slook/pyTermTk/demo/showcase/colorpicker.py", line 82, in main
    root.mainloop()
  File "/home/user/Git/slook/pyTermTk/demo/showcase/../../libs/pyTermTk/TermTk/TTkCore/ttk.py", line 144, in mainloop
    self._mainloop_1()
  File "/home/user/Git/slook/pyTermTk/demo/showcase/../../libs/pyTermTk/TermTk/TTkCore/ttk.py", line 189, in _mainloop_1
    self._mainLoop_2()
  File "/home/user/Git/slook/pyTermTk/demo/showcase/../../libs/pyTermTk/TermTk/TTkCore/ttk.py", line 212, in _mainLoop_2
    TTkInput.start()
  File "/home/user/Git/slook/pyTermTk/demo/showcase/../../libs/pyTermTk/TermTk/TTkCore/TTkTerm/input_thread.py", line 102, in start
    TTkInput.inputEvent.emit(kevt, mevt)
  File "/home/user/Git/slook/pyTermTk/demo/showcase/../../libs/pyTermTk/TermTk/TTkCore/signal.py", line 187, in emit
    slot(*args[sl], **kwargs)
  File "/home/user/Git/slook/pyTermTk/demo/showcase/../../libs/pyTermTk/TermTk/TTkCore/ttk.py", line 226, in _processInput
    self._mouse_event(mevt)
  File "/home/user/Git/slook/pyTermTk/demo/showcase/../../libs/pyTermTk/TermTk/TTkCore/ttk.py", line 256, in _mouse_event
    focusWidget.mouseEvent(nmevt)
  File "/home/user/Git/slook/pyTermTk/demo/showcase/../../libs/pyTermTk/TermTk/TTkWidgets/widget.py", line 455, in mouseEvent
    if self.mouseDragEvent(evt):
       ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Git/slook/pyTermTk/demo/showcase/../../libs/pyTermTk/TermTk/TTkWidgets/TTkPickers/colorpicker.py", line 71, in mouseDragEvent
    return self.mousePressEvent(evt)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Git/slook/pyTermTk/demo/showcase/../../libs/pyTermTk/TermTk/TTkWidgets/TTkPickers/colorpicker.py", line 66, in mousePressEvent
    self.colorPicked.emit(self._hueList[evt.x])
                          ~~~~~~~~~~~~~^^^^^^^
IndexError: list index out of range


------------------
(program exited with code: 1)
Press return to continue
```