### PR TITLE
feat(textcursor): Move to the start of the document

### DIFF
--- a/libs/pyTermTk/TermTk/TTkGui/textcursor.py
+++ b/libs/pyTermTk/TermTk/TTkGui/textcursor.py
@@ -331,6 +331,8 @@ class TTkTextCursor():
         def moveEnd(cID,p,_):
             l = self._document._dataLines[-1]
             self.setPosition(len(self._document._dataLines)-1, len(l), moveMode, cID=cID)
+        def moveStart(cID,_p,_n):
+            self.setPosition(0, 0, moveMode, cID=cID)
 
         op = {
                 TTkTextCursor.Right : moveRight,
@@ -340,6 +342,7 @@ class TTkTextCursor():
                 TTkTextCursor.EndOfLine  : moveEndOfLine,
                 TTkTextCursor.StartOfLine: moveHome,
                 TTkTextCursor.End: moveEnd,
+                TTkTextCursor.Start: moveStart,
             }.get(operation,lambda _:_)
 
         for _ in range(n):


### PR DESCRIPTION
+ Added: missing `moveStart()` operation in `movePosition()` method of `TTkTextCursor()` to resolve unexpected _"TypeError: TTkTextCursor.movePosition.<locals>.<lambda>() takes 1 positional argument but 3 were given"_

[TTkTextCursor.movePosition](https://ceccopierangiolieugenio.github.io/pyTermTk-Docs/_autosummary/TermTk.TTkGui.TTkTextCursor.html#TermTk.TTkGui.TTkTextCursor.movePosition)([TTkTextCursor.MoveOperation.Start](https://ceccopierangiolieugenio.github.io/pyTermTk-Docs/_autosummary/TermTk.TTkGui.TTkTextCursor.html#TermTk.TTkGui.TTkTextCursor.MoveOperation.Start))

> **`Start` = 1**
>     Move to the start of the document.