### PR TITLE
fix(textcursor): correct number of Up/Down movements

### DIFF
--- a/libs/pyTermTk/TermTk/TTkGui/textcursor.py
+++ b/libs/pyTermTk/TermTk/TTkGui/textcursor.py
@@ -315,11 +315,11 @@ class TTkTextCursor():
             elif p.line > 0:
                 self.setPosition(p.line-1, len(self._document._dataLines[p.line-1]) , moveMode, cID=cID)
         def moveUpDown(offset):
-            def _moveUpDown(cID,p,n):
+            def _moveUpDown(cID,p,_n):
                 if not textWrap:
                     raise ValueError("textWrap is required for the Up,Down movement")
                 cx, cy    = textWrap.dataToScreenPosition(p.line, p.pos)
-                x,  y     = textWrap.normalizeScreenPosition(cx,cy+offset*n)
+                x,  y     = textWrap.normalizeScreenPosition(cx,cy+offset)
                 line, pos = textWrap.screenToDataPosition(x,y)
                 self.setPosition(line, pos, moveMode, cID=cID)
             return _moveUpDown


### PR DESCRIPTION
- Changed: Don't do recursive multiplication of `n` because it is already iterated for the required number of movePosition operations as this sub-procedure is called from within a `for` loop.

In future it might be considered better performance to do all moves in one go for relevant operations (Up, Down, Left, Right), but for now this at least fixes the function that was otherwise off by `n` orders of magnitude when `n` is more than `1`.