### PR TITLE
fix(menu): don't prevent setting the text color of an item

### DIFF
--- a/libs/pyTermTk/TermTk/TTkWidgets/menu.py
+++ b/libs/pyTermTk/TermTk/TTkWidgets/menu.py
@@ -155,7 +155,6 @@ class TTkMenuButton(TTkWidget):
         :param text:
         :type text: :py:class:`TTkString`
         '''
-        if self._text == text: return
         self._text = TTkString(text)
         self.textChanged.emit(self._text)
         self.update()


### PR DESCRIPTION
- Removed: a pointless check condition which meant the text could only be changed with a `TTkString` if it contained different `text` but not only a different `color`. This check is not required since `setText()` has to be called explicitly so setting a new `text` value is always wanted in any case.

For instance, you might want to make the existing text of a menu item bold or colored or blinking or whatever without actually changing what the string says, but the comparison check was done on the only the raw `str` value such as is returned by the TTkString constructor preventing such formatting changes from being made to the property.