### PR TITLE
feat(demo): track mouse by default

### DIFF
--- a/demo/demo.py
+++ b/demo/demo.py
@@ -234,12 +234,12 @@ def demoShowcase(root=None, border=True):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-f', help='Full Screen (default)', action='store_true')
-    parser.add_argument('-w', help='Windowed',    action='store_true')
-    parser.add_argument('-t', help='Track Mouse', action='store_true')
+    parser.add_argument('-f', help="Full Screen (default)", action='store_true')
+    parser.add_argument('-w', help="Windowed",              action='store_true')
+    parser.add_argument('-t', help="Don't Track Mouse",     action='store_true')
     args = parser.parse_args()
     windowed = args.w
-    mouseTrack = args.t
+    mouseTrack = not args.t
 
     root = ttk.TTk(title="pyTermTk Demo", mouseTrack=mouseTrack)
     if windowed:


### PR DESCRIPTION
- Changed: Invert the `-t` argument of the demo app to disable mouse tracking rather than enable it, and enable it by default.

Plenty of the widgets respond to mouse hover events and this is an impressive feature to showcase in the demo app as well as helping us to ensure that mouse tracking behaviours are routinely tested when developing new widgets and library features such as `ToolTip`s for instance.

I tested it in the pyodide sandbox and mouse tracking works just fine in the browser too. There is an argument to be made that perhaps `mouseTrack` could be `True` by default in `TTk` core?