### PR TITLE
fix(tabwidget): emit button clicked signal last

### DIFF
--- a/libs/pyTermTk/TermTk/TTkWidgets/tabwidget.py
+++ b/libs/pyTermTk/TermTk/TTkWidgets/tabwidget.py
@@ -747,8 +747,8 @@ class TTkTabBar(TTkContainer):
     @pyTTkSlot(TTkTabButton)
     def _tcbClickedHandler(self, btn:TTkTabButton):
         index = self._tabStatus.tabButtons.index(btn)
-        self.setCurrentIndex(index)
         self.tabBarClicked.emit(index)
+        self.setCurrentIndex(index)
 
     @pyTTkSlot(int)
     def removeTab(self, index:int) -> None:


### PR DESCRIPTION
- Fixed: Emit clicked signal for the button after the clicked signal for the bar instead of beforehand
 
Otherwise using `setFocus()` to focus a particular widget in a `currentChanged` slot doesn't work like it did before #537 because when using the mouse to select a tab button, the focus gets unexpectedly trapped onto the tab bar.

It is often wanted to choose a default widget to be focused upon changing to a different tab, so to avoid the focus being stolen back again it is necessary that this signal is the last signal to be emitted by the widget during a mouse clicked event.