### PR TITLE
fix(combobox): allow adding to layout of overlay

### DIFF
--- a/libs/pyTermTk/TermTk/TTkWidgets/combobox.py
+++ b/libs/pyTermTk/TermTk/TTkWidgets/combobox.py
@@ -158,12 +158,13 @@ class TTkComboBox(TTkContainer):
         self.currentIndexChanged = pyTTkSignal(int)
         self.currentTextChanged  = pyTTkSignal(str)
         self.editTextChanged     = pyTTkSignal(str)
-        super().__init__(**kwargs)
         # self.checked = pyTTkSignal()
-        self._lineEdit = TTkLineEdit(parent=self)
+        self._lineEdit = TTkLineEdit()
+        super().__init__(**kwargs)
+        self._lineEdit.setParent(self)
+        self._lineEdit.returnPressed.connect(self._lineEditChanged)
         self._list =  list if list else []
         self._insertPolicy = insertPolicy
-        self._lineEdit.returnPressed.connect(self._lineEditChanged)
         self._textAlign = textAlign
         self._id = index
         self._popupFrame = None


### PR DESCRIPTION
- Fixed: avoid crash when adding the widget to a layout of an overlay that doesn't yet have a parent.

Such a crash occurs in several scenarios that make this widget difficult to implement. For example:
 
```
AttributeError: 'TTkComboBox' object has no attribute '_lineEdit'

Nicotine+ Version: 3.4.0.dev1
TTk Version: 0.48.1-a0
Python Version: 3.11.2 (linux)

Type: <class 'AttributeError'>
Value: 'TTkComboBox' object has no attribute '_lineEdit'
Traceback:
  File "/usr/lib/python3.11/threading.py", line 1038, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.11/threading.py", line 975, in run
    self._target(*self._args, **self._kwargs)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkCore/ttk.py", line 186, in mainloop
    self._mainloop()
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkCore/ttk.py", line 224, in _mainloop
    TTkInput.start()
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkCore/TTkTerm/input_thread.py", line 107, in start
    TTkInput.inputEvent.emit(kevt, mevt)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkCore/signal.py", line 187, in emit
    slot(*args[sl], **kwargs)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkCore/ttk.py", line 295, in _processInput
    self._mouse_event(mevt)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkCore/ttk.py", line 324, in _mouse_event
    focusWidget.mouseEvent(nmevt)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkWidgets/widget.py", line 515, in mouseEvent
    if self.mouseReleaseEvent(evt):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkWidgets/button.py", line 236, in mouseReleaseEvent
    self.clicked.emit()
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkCore/signal.py", line 187, in emit
    slot(*args[sl], **kwargs)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/ttktui/dialogs/preferences.py", line 337, in on_edit_shared_folder
    EntryDialog(
  File "/home/user/Git/slook/nicotine-plus/pynicotine/ttktui/widgets/dialogs.py", line 221, in __init__
    self.options[option_name] = self.add_entry(
                                ^^^^^^^^^^^^^^^
  File "/home/user/Git/slook/nicotine-plus/pynicotine/ttktui/widgets/dialogs.py", line 245, in add_entry
    entry = ttk.TTkComboBox(parent=box, list=droplist, editable=editable, insertPolicy=ttk.TTkK.NoInsert)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkWidgets/combobox.py", line 161, in __init__
    super().__init__(**kwargs)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkWidgets/container.py", line 153, in __init__
    super().__init__(**kwargs)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkWidgets/widget.py", line 269, in __init__
    self._parent.layout().addWidget(self)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkLayouts/gridlayout.py", line 190, in addWidget
    TTkGridLayout.addWidgets(self,[widget], row, col, rowspan, colspan, direction)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkLayouts/gridlayout.py", line 206, in addWidgets
    TTkGridLayout.addItems(self, items, row, col, rowspan, colspan, direction)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkLayouts/gridlayout.py", line 274, in addItems
    TTkLayout.addItems(self, items)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkLayouts/layout.py", line 272, in addItems
    self.insertItems(len(self._items),items)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkLayouts/layout.py", line 292, in insertItems
    self.parentWidget().update(repaint=True, updateLayout=True)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkWidgets/container.py", line 466, in update
    self.rootLayout().update()
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkLayouts/layout.py", line 414, in update
    ret = ret or i.update(*args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkLayouts/gridlayout.py", line 480, in update
    item.setGeometry(x, y, w, h)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkLayouts/layout.py", line 446, in setGeometry
    self._widget.setGeometry(x, y, w, h)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkWidgets/widget.py", line 416, in setGeometry
    self.resize(width, height)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkWidgets/widget.py", line 401, in resize
    self.resizeEvent(width,height)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkWidgets/combobox.py", line 261, in resizeEvent
    self._lineEdit.setGeometry(1,0,width-4,height)
    ^^^^^^^^^^^^^^

Quitting Nicotine+ 3.4.0.dev1, application closing…
Unloaded plugin Test Plugin
[Misc] Backed up and saved file /home/user/.config/nicotine/config
Quit Nicotine+ 3.4.0.dev1!
```