### PR TITLE
fix(tree): invert SortOrder on header clicked

### DIFF
--- a/libs/pyTermTk/TermTk/TTkCore/constant.py
+++ b/libs/pyTermTk/TermTk/TTkCore/constant.py
@@ -281,9 +281,9 @@ class TTkConstant:
 
         def invert(order:TTkConstant.SortOrder) -> TTkConstant.SortOrder:
             if order == TTkConstant.SortOrder.AscendingOrder:
-                return TTkConstant.SortOrder.AscendingOrder
-            else:
                 return TTkConstant.SortOrder.DescendingOrder
+            else:
+                return TTkConstant.SortOrder.AscendingOrder
 
     AscendingOrder  = SortOrder.AscendingOrder
     DescendingOrder = SortOrder.DescendingOrder


### PR DESCRIPTION
- Fixed: Actually `invert()` the `SortOrder` to the opposite direction when the column header of a `TTkTreeWidget` is clicked.