### PR TITLE
feat(keypressview): exclude mouse move events

### DIFF
--- a/libs/pyTermTk/TermTk/TTkTestWidgets/keypressview.py
+++ b/libs/pyTermTk/TermTk/TTkTestWidgets/keypressview.py
@@ -69,10 +69,14 @@ class TTkKeyPressView(TTkWidget):
     def _addMouse(self, evt):
               # return f"MouseEvent ({self.x},{self.y}) {self.key2str()} {self.evt2str()} {self.mod2str()} tap:{self.tap} - {self.raw}"
         # text = f"M:{(evt.x,evt.y)} {evt.key2str().replace('Button','')} {evt.evt2str().replace('Release','').replace('Press','')} {evt.mod2str().replace('NoModifier','')}"
+        if evt.key==TTkMouseEvent.NoButton: return
         tap = " "
+        if evt.tap==1: tap=" Click "
         if evt.tap==2: tap=" DoubleClick "
         if evt.tap==3: tap=" TripleClick "
         if evt.tap>3:  tap=f" {evt.tap} Clicks "
+        if evt.evt==TTkMouseEvent.Drag: tap=" Drag "
+        if evt.evt==TTkMouseEvent.Release: tap+="Release "
 
         text = f"M:{(evt.x,evt.y)} {evt.key2str().replace('Button','')}{tap}{evt.mod2str().replace('NoModifier','')}"
         self._keys.append([1,text,0x100])


### PR DESCRIPTION
- Removed: Don't display mouse move events when no button is pressed.
- Changed: Display " Click " text instead of an empty string for single-click.
- Added: Display "Drag" event with coordinates while dragging is in progress.
- Added: Display "Release" event to avoid incorrectly reporting click events.

The widget isn't suitable for constantly showing the position of the mouse coordinates due to the fade effect not being performant enough, and showing that information wipes out the more relevant events from being displayed for long.