### PR TITLE
fix(combobox): enter spaces in editable

### DIFF
--- a/libs/pyTermTk/TermTk/TTkWidgets/combobox.py
+++ b/libs/pyTermTk/TermTk/TTkWidgets/combobox.py
@@ -438,8 +438,9 @@ class TTkComboBox(TTkContainer):
         return True
 
     def keyEvent(self, evt:TTkKeyEvent) -> bool:
-        if ( evt.type == TTkK.Character and evt.key==" " ) or \
-           ( evt.type == TTkK.SpecialKey and evt.key in [TTkK.Key_Enter,TTkK.Key_Down] ):
+        if ((evt.type == TTkK.SpecialKey and evt.key==TTkK.Key_Down) or
+                not self._editable and (evt.type == TTkK.Character and evt.key==" " or
+                                        evt.type == TTkK.SpecialKey and evt.key==TTkK.Key_Enter)):
             self._pressEvent()
             return True
         return super().keyEvent(evt=evt)


### PR DESCRIPTION
Draft, testing handling of key press events for different purposes depending upon how the widget is configured, otherwise space characters can't be included in manually entered values and the overlay list often appears when it's not appropriate.

- Changed: Don't open overlay list when typing space characters into an editable ComboBox.
- Removed: Don't open overlay list when pressing return/enter key on and editable ComboBox, as this hinders entered data being emitted elsewhere.

`▽`