### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,5 +1,8 @@
 name: Testing
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/ceccopierangiolieugenio/pyTermTk/security/code-scanning/7](https://github.com/ceccopierangiolieugenio/pyTermTk/security/code-scanning/7)

In general, the problem is fixed by explicitly specifying a minimal `permissions:` block for the workflow or for each job, instead of relying on repository defaults. For a test workflow that only checks out code and runs tests, `contents: read` is sufficient in most cases.

The best fix here is to add a workflow-level `permissions:` block near the top of `.github/workflows/testing.yml`, so it applies to both `test-autogen` and `test-pyTermTk` without changing job behavior. Based on the shown steps, neither job needs to modify repository contents via the GitHub API; they only need to read repository code (`actions/checkout`) and run local Git operations. Therefore, setting `permissions: contents: read` at the root is appropriate and adheres to least privilege. Concretely, insert:

```yaml
permissions:
  contents: read
```

between the `name: Testing` line and the existing `concurrency:` block. No other lines need to be modified, and no additional imports or methods are required because this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
