### PR TITLE
fix(TTkTabBar): currentIndex <= highlighted TypeError

### DIFF
--- a/libs/pyTermTk/TermTk/TTkWidgets/tabwidget.py
+++ b/libs/pyTermTk/TermTk/TTkWidgets/tabwidget.py
@@ -121,7 +121,7 @@ class _TTkTabStatus():
     #     self._setCurrentIndex(index)
 
     def _selectHighlighted(self) -> None:
-        if self.highlighted:
+        if self.highlighted is not None:
             self._setCurrentIndex(self.highlighted)
 
     @pyTTkSlot(int)


### PR DESCRIPTION
Fixes #592

- Fixed: Crash on press Space or Enter key on same tab that is currently selected (without moving it to the left nor to the right)
- Removed: Unused method _resetHighlighted() because nothing calls it