### PR TITLE
fix(canvas): allow doubleBufferNew missing _link

### DIFF
--- a/libs/pyTermTk/TermTk/TTkCore/canvas.py
+++ b/libs/pyTermTk/TermTk/TTkCore/canvas.py
@@ -801,7 +801,7 @@ class TTkCanvas():
                 empty=True
         # Reset the color at the end
         TTkTerm.push(TTkColor.RST)
-        if lastcolor._link:
+        if getattr(lastcolor, "_link", False):
             TTkTerm.push("\033]8;;\033\\")
         # Switch the buffer
         self._bufferedData, self._bufferedColors = data, colors


### PR DESCRIPTION
avoid AttributeError: 'TTkColor' object has no attribute '_link'

`TTkCfg.doubleBufferNew = True`

```
Traceback (most recent call last):
  File "/home/user/Git/slook/pyTermTk/demo/demo.py", line 258, in <module>
    main()
  File "/home/user/Git/slook/pyTermTk/demo/demo.py", line 255, in main
    root.mainloop()
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkCore/ttk.py", line 184, in mainloop
    self._mainloop()
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkCore/ttk.py", line 238, in _mainloop
    raise e
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkCore/timer_unix.py", line 68, in run
    self.timeout.emit()
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkCore/signal.py", line 187, in emit
    slot(*args[sl], **kwargs)
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkCore/ttk.py", line 369, in _time_event
    TTkHelper.paintAll()
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkCore/helper.py", line 222, in paintAll
    TTkHelper._rootCanvas.pushToTerminalBufferedNew(0, 0, TTkGlbl.term_w, TTkGlbl.term_h)
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkCore/canvas.py", line 804, in pushToTerminalBufferedNew
    if lastcolor._link:
       ^^^^^^^^^^^^^^^
AttributeError: 'TTkColor' object has no attribute '_link'
```