### PR TITLE
fix(splitter): process sizes in setOrientation()

### DIFF
--- a/libs/pyTermTk/TermTk/TTkWidgets/splitter.py
+++ b/libs/pyTermTk/TermTk/TTkWidgets/splitter.py
@@ -168,6 +168,9 @@ class TTkSplitter(TTkContainer):
         if orientation == self._orientation: return
         if orientation not in (TTkK.HORIZONTAL, TTkK.VERTICAL): return
         self._orientation = orientation
+        w,h = self.size()
+        b = 2 if self._border else 0
+        self._processRefSizes(w-b,h-b)
         self._updateGeometries()
 
     def clean(self) -> None:


### PR DESCRIPTION
- Fixed: Use the reference sizes of the new orientation for updating geometries

Otherwise a visual glitch occurs because the old sizes from the previous orientation are used which resulted in incorrect widget geometries until the splitter had to be manually adjusted for the layout to correct itself.