### PR TITLE
chore(combobox): extend items

### DIFF
--- a/libs/pyTermTk/TermTk/TTkWidgets/combobox.py
+++ b/libs/pyTermTk/TermTk/TTkWidgets/combobox.py
@@ -303,8 +303,8 @@ class TTkComboBox(TTkContainer):
         :param items:
         :type items: list[str]
         '''
-        for item in items:
-            self.addItem(item)
+        self._list.extend(items)
+        self.update()
 
     pyTTkSlot()
     def clear(self) -> None:


### PR DESCRIPTION
Minor performance improvement. Avoids unnecessary `update()` calls when appending each item when adding a list of items.