### PR TITLE
fix(canvas): unbuffered pushToTerminal missing _clean

### DIFF
--- a/libs/pyTermTk/TermTk/TTkCore/canvas.py
+++ b/libs/pyTermTk/TermTk/TTkCore/canvas.py
@@ -705,7 +705,7 @@ class TTkCanvas():
         # TTkLog.debug("pushToTerminal")
         lastcolor = TTkColor.RST
         for y in range(0, self._height):
-            ansi = lastcolor+TTkTerm.Cursor.moveTo(y+1,1)
+            ansi = str(lastcolor)+TTkTerm.Cursor.moveTo(y+1,1)
             for x in range(0, self._width):
                 ch = self._data[y][x]
                 color = self._colors[y][x]


### PR DESCRIPTION
- Fixed: AttributeError crash on start with double-buffering completely disabled

```
    doubleBuffer:bool = False
    doubleBufferNew:bool = False
```

```
Traceback (most recent call last):
  File "/home/user/Git/slook/pyTermTk/demo/demo.py", line 258, in <module>
    main()
  File "/home/user/Git/slook/pyTermTk/demo/demo.py", line 255, in main
    root.mainloop()
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkCore/ttk.py", line 184, in mainloop
    self._mainloop()
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkCore/ttk.py", line 238, in _mainloop
    raise e
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkCore/timer_unix.py", line 68, in run
    self.timeout.emit()
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkCore/signal.py", line 187, in emit
    slot(*args[sl], **kwargs)
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkCore/ttk.py", line 369, in _time_event
    TTkHelper.paintAll()
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkCore/helper.py", line 224, in paintAll
    TTkHelper._rootCanvas.pushToTerminal(0, 0, TTkGlbl.term_w, TTkGlbl.term_h)
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkCore/canvas.py", line 708, in pushToTerminal
    ansi = lastcolor+TTkTerm.Cursor.moveTo(y+1,1)
           ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkCore/color.py", line 437, in __add__
    if other._clean:
       ^^^^^^^^^^^^
AttributeError: 'str' object has no attribute '_clean'
```