### PR TITLE
fix(TTkLineEdit): paste str

### DIFF
--- a/libs/pyTermTk/TermTk/TTkWidgets/lineedit.py
+++ b/libs/pyTermTk/TermTk/TTkWidgets/lineedit.py
@@ -353,7 +353,7 @@ class TTkLineEdit(TTkWidget):
         ''' Paste text from the clipboard at the cursor position
         '''
         txt = self._clipboard.text()
-        self.pasteEvent(txt)
+        self.pasteEvent(str(txt))
 
     def pasteEvent(self, txt:str):
         ''' Handle paste event with custom text


### PR DESCRIPTION
- Fixed: TypeError crash on paste str type from TTkString() in TTkClipboard() but TTkLineEdit() only supports plain string type

To reproduce the crash, cut (Ctrl+X) some text from any widget then paste (Ctrl+V) into a LineEdit or editable Combobox...

```
Traceback (most recent call last):
  File "/home/user/Git/slook/pyTermTk/demo/demo.py", line 258, in <module>
    main()
  File "/home/user/Git/slook/pyTermTk/demo/demo.py", line 255, in main
    root.mainloop()
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkCore/ttk.py", line 184, in mainloop
    self._mainloop()
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkCore/ttk.py", line 228, in _mainloop
    TTkInput.start()
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkCore/TTkTerm/input_thread.py", line 107, in start
    TTkInput.inputEvent.emit(kevt, mevt)
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkCore/signal.py", line 187, in emit
    slot(*args[sl], **kwargs)
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkCore/ttk.py", line 298, in _processInput
    self.keyEvent(kevt)
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkWidgets/rootcontainer.py", line 398, in keyEvent
    if super().keyEvent(evt=evt):
       ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkWidgets/container.py", line 224, in keyEvent
    if _cfw._enabled and _cfw.keyEvent(evt):
                         ^^^^^^^^^^^^^^^^^^
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkWidgets/container.py", line 224, in keyEvent
    if _cfw._enabled and _cfw.keyEvent(evt):
                         ^^^^^^^^^^^^^^^^^^
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkWidgets/container.py", line 224, in keyEvent
    if _cfw._enabled and _cfw.keyEvent(evt):
                         ^^^^^^^^^^^^^^^^^^
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkWidgets/tabwidget.py", line 1069, in keyEvent
    return super().keyEvent(evt)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkWidgets/container.py", line 224, in keyEvent
    if _cfw._enabled and _cfw.keyEvent(evt):
                         ^^^^^^^^^^^^^^^^^^
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkWidgets/container.py", line 224, in keyEvent
    if _cfw._enabled and _cfw.keyEvent(evt):
                         ^^^^^^^^^^^^^^^^^^
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkWidgets/lineedit.py", line 404, in keyEvent
    self.paste()
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkWidgets/lineedit.py", line 356, in paste
    self.pasteEvent(txt)
  File "/home/user/Git/slook/pyTermTk/demo/../libs/pyTermTk/TermTk/TTkWidgets/lineedit.py", line 366, in pasteEvent
    ttk_txt = TTkString(''.join(txt.split('\n')))
                        ^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: sequence item 0: expected str instance, TTkString found
```