### PR TITLE
build(deps): bump requests from 2.32.5 to 2.33.0 in /tools/ci

### DIFF
--- a/tools/ci/pyproject.toml
+++ b/tools/ci/pyproject.toml
@@ -17,7 +17,7 @@
 [project.optional-dependencies]
     social = [
         'discord.py==2.5.2',
-        'requests==2.32.5',
+        'requests==2.33.0',
         'requests_oauthlib==2.0.0'
     ]
 


### PR DESCRIPTION
https://github.com/ceccopierangiolieugenio/pyTermTk/security/dependabot/16

> Impact
> The requests.utils.extract_zipped_paths() utility function uses a predictable filename when extracting files from zip archives into the system temporary directory. If the target file already exists, it is reused without validation. A local attacker with write access to the temp directory could pre-create a malicious file that would be loaded in place of the legitimate one.
> 
> Affected usages
> Standard usage of the Requests library is not affected by this vulnerability. Only applications that call extract_zipped_paths() directly are impacted.
> 
> Remediation
> Upgrade to at least Requests 2.33.0, where the library now extracts files to a non-deterministic location.
> 
> If developers are unable to upgrade, they can set TMPDIR in their environment to a directory with restricted write access.