### PR TITLE
fix(drivers): run on BSD and other unix

### DIFF
--- a/libs/pyTermTk/TermTk/TTkCore/drivers/__init__.py
+++ b/libs/pyTermTk/TermTk/TTkCore/drivers/__init__.py
@@ -5,7 +5,17 @@ if importlib.util.find_spec('pyodideProxy'):
     from .pyodide import *
     from .term_pyodide import *
 
-elif platform.system() == 'Linux':
+elif platform.system() == 'Windows':
+    from .windows import *
+    from .term_windows import *
+
+elif platform.system() == 'Darwin':
+    from .unix import *
+    from .term_unix_darwin import *
+
+else:
+    # print(platform.system())
+    # ('Linux', 'OpenBSD', 'FreeBSD', 'NetBSD', 'Haiku', 'SunOS')
     import os
 
     if os.environ.get("TERMTK_GPM",False):
@@ -19,12 +29,3 @@ elif platform.system() == 'Linux':
         else:
             # from .term_unix import *
             from .term_unix_linux import *
-
-elif platform.system() == 'Darwin':
-    from .unix import *
-    # from .term_unix import *
-    from .term_unix_darwin import *
-
-elif platform.system() == 'Windows':
-    from .windows import *
-    from .term_windows import *


### PR DESCRIPTION
- Fixed: ImportError when running unittests on BSD and derivatives

_[Example CI runner output](https://github.com/slook/nicotine-plus/actions/runs/25262743846/job/74072585587#step:3:141) on OpenBSD (same exception was in my runners for FreeBSD, Solaris, etc):_
```
test_tui_startup (pynicotine.tests.integration.test_startup.StartupTest.test_tui_startup)
Verify that TermTk TUI startup works. ... Using TTk executable: /home/runner/work/nicotine-plus/nicotine-plus/pynicotine/external/pyTermTk
OpenBSD
Unsupported system.
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/runner/work/nicotine-plus/nicotine-plus/pynicotine/__main__.py", line 7, in <module>
    sys.exit(run())
             ^^^^^
  File "/home/runner/work/nicotine-plus/nicotine-plus/pynicotine/__init__.py", line 224, in run
    exit_code = application.run(ci_mode, isolated_mode)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/nicotine-plus/nicotine-plus/pynicotine/ttktui/__init__.py", line 29, in run
    error = check_ttk_version()
            ^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/nicotine-plus/nicotine-plus/pynicotine/ttktui/__init__.py", line 11, in check_ttk_version
    from TermTk import __version__ as TTk_version
  File "/home/runner/work/nicotine-plus/nicotine-plus/pynicotine/external/pyTermTk/TermTk/__init__.py", line 25, in <module>
    from .TTkTheme       import *
  File "/home/runner/work/nicotine-plus/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkTheme/__init__.py", line 1, in <module>
    from .theme import *
  File "/home/runner/work/nicotine-plus/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkTheme/theme.py", line 25, in <module>
    from TermTk.TTkCore.color import TTkColor
  File "/home/runner/work/nicotine-plus/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkCore/__init__.py", line 6, in <module>
    from .helper   import *
  File "/home/runner/work/nicotine-plus/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkCore/helper.py", line 30, in <module>
    from TermTk.TTkCore.TTkTerm.term import TTkTerm
  File "/home/runner/work/nicotine-plus/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkCore/TTkTerm/__init__.py", line 4, in <module>
    from .input      import *
  File "/home/runner/work/nicotine-plus/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkCore/TTkTerm/input.py", line 26, in <module>
    from .input_thread import TTkInput
  File "/home/runner/work/nicotine-plus/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkCore/TTkTerm/input_thread.py", line 32, in <module>
    from ..drivers import TTkInputDriver
ImportError: cannot import name 'TTkInputDriver' from 'TermTk.TTkCore.drivers' (/home/runner/work/nicotine-plus/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkCore/drivers/__init__.py)
FAIL
```

_[After fix](https://github.com/slook/nicotine-plus/actions/runs/25264989233/job/74077950254#step:3:108) in this PR (my project's CI runner is currently only able to test that the library is successfully imported):_
```
Verify that TermTk TUI startup works. ... Using TTk executable: /home/runner/work/nicotine-plus/nicotine-plus/pynicotine/external/pyTermTk
OpenBSD
Imported TermTk 0.49.0-a0
Loaded TTk 0.49.0-a0
Nicotine+ TTk loaded okay, but not a TTY!
ok
```

Note this fix assumes that 'OpenBSD', 'FreeBSD', 'NetBSD', 'Haiku', 'SunOS' are all like 'Linux', but those operating systems cannot actually be tested at runtime by anyone currently because this `ImportError` makes running on those platforms impossible for no good reason (the Linux driver should work on any platform that has the standard `termios` package).

If any issues are reported then alternate terminal driver modules can be imported for different platforms if required.