### PR TITLE
fix(docs): support optimized cx_Freeze packaging

### DIFF
--- a/libs/pyTermTk/TermTk/TTkWidgets/TTkModelView/filetree.py
+++ b/libs/pyTermTk/TermTk/TTkWidgets/TTkModelView/filetree.py
@@ -36,7 +36,7 @@ class TTkFileTree(TTkTree):
     __doc__ = '''
     :py:class:`TTkFileTree` is a container widget which place :py:class:`TTkFileTreeWidget` in a scrolling area with on-demand scroll bars.
 
-    ''' + TTkFileTreeWidget.__doc__
+    ''' + (TTkFileTreeWidget.__doc__ or '')
 
     _ttk_forward = _ForwardData(
         forwardClass=TTkFileTreeWidget,

--- a/libs/pyTermTk/TermTk/TTkWidgets/TTkModelView/table.py
+++ b/libs/pyTermTk/TermTk/TTkWidgets/TTkModelView/table.py
@@ -35,7 +35,7 @@ class TTkTable(TTkAbstractScrollArea):
     __doc__ = '''
     :py:class:`TTkTable` is a container widget which place :py:class:`TTkTableWidget` in a scrolling area with on-demand scroll bars.
 
-    ''' + str(TTkTableWidget.__doc__)
+    ''' + (TTkTableWidget.__doc__ or '')
 
     classStyle = TTkTableWidget.classStyle
 

--- a/libs/pyTermTk/TermTk/TTkWidgets/TTkModelView/tree.py
+++ b/libs/pyTermTk/TermTk/TTkWidgets/TTkModelView/tree.py
@@ -35,7 +35,7 @@ class TTkTree(TTkAbstractScrollArea):
     __doc__ = '''
     :py:class:`TTkTree` is a container widget which place :py:class:`TTkTreeWidget` in a scrolling area with on-demand scroll bars.
 
-    ''' + TTkTreeWidget.__doc__
+    ''' + (TTkTreeWidget.__doc__ or '')
 
     _ttk_forward = _ForwardData(
         forwardClass=TTkTreeWidget ,

--- a/libs/pyTermTk/TermTk/TTkWidgets/TTkTerminal/terminal.py
+++ b/libs/pyTermTk/TermTk/TTkWidgets/TTkTerminal/terminal.py
@@ -34,7 +34,7 @@ class TTkTerminal(TTkAbstractScrollArea):
     __doc__ = '''
     :py:class:`TTkTerminal` is a container widget which place :py:class:`TTkTerminalView` in a scrolling area with on-demand scroll bars.
 
-    ''' + TTkTerminalView.__doc__
+    ''' + (TTkTerminalView.__doc__ or '')
 
     _ttk_forward = _ForwardData(
         forwardClass=TTkTerminalView ,

--- a/libs/pyTermTk/TermTk/TTkWidgets/list_.py
+++ b/libs/pyTermTk/TermTk/TTkWidgets/list_.py
@@ -33,7 +33,7 @@ class TTkList(TTkAbstractScrollArea):
     __doc__ = '''
     :py:class:`TTkList` is a container widget which place :py:class:`TTkListWidget` in a scrolling area with on-demand scroll bars.
 
-    ''' + TTkListWidget.__doc__
+    ''' + (TTkListWidget.__doc__ or '')
 
     _ttk_forward = _ForwardData(
         forwardClass=TTkListWidget ,

--- a/libs/pyTermTk/TermTk/TTkWidgets/text_edit.py
+++ b/libs/pyTermTk/TermTk/TTkWidgets/text_edit.py
@@ -43,7 +43,7 @@ class TTkTextEdit(TTkAbstractScrollArea):
     __doc__ = '''
     :py:class:`TTkTextEdit` is a container widget which place :py:class:`TTkTextEditView` in a scrolling area with on-demand scroll bars.
 
-    ''' + (TTkTextEditView.__doc__ if TTkTextEditView.__doc__ else '')
+    ''' + (TTkTextEditView.__doc__ or '')
 
     ExtraSelection = TTkTextEditView.ExtraSelection
 


### PR DESCRIPTION
- Fixed: Avoid `TypeError`s when using [cx_Freeze](https://github.com/marcelotduarte/cx_Freeze) to compile a Windows or Darwin binary containing a bundled TTk library

[cx_Freeze](https://github.com/marcelotduarte/cx_Freeze) can strip all docstrings (equivalent to Python's `-OO` flag) to optimize the executable file size, making `__doc__` return `None`. The library then fails the testrun after build-time when it tries to concatenate None to a string.

_[Example CI packaging GH actions runner output](https://github.com/slook/nicotine-plus/actions/runs/25263305360/job/74073987200) (similar exception was on both my Windows and macOS builds):_
```
Run python3 build-aux/windows/testrun.py
  python3 build-aux/windows/testrun.py
  shell: C:\Windows\system32\cmd.EXE /D /E:ON /V:OFF /S /C "CALL "{0}""
  env:
    ARCH: x86_64
    MSYSTEM: CLANG64
Using TTk executable: D:/a/nicotine-plus/nicotine-plus/build-aux/windows/build/package/Nicotine+/lib/pynicotine/external/pyTermTk
Windows
Traceback (most recent call last):
  File "D:/a/_temp/msys64/clang64/lib/python3.14/site-packages/freeze_core/initscripts/__startup__.py", line 137, in run
    module_init.run(f"__main__{name}")
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "D:/a/_temp/msys64/clang64/lib/python3.14/site-packages/freeze_core/initscripts/console.py", line 27, in run
    exec(code, main_globals)
    ~~~~^^^^^^^^^^^^^^^^^^^^
  File "D:/a/nicotine-plus/nicotine-plus/nicotine", line 30, in <module>
    sys.exit(load_module())
             ~~~~~~~~~~~^^
  File "D:/a/nicotine-plus/nicotine-plus/nicotine", line 20, in load_module
    return pynicotine.run()
           ~~~~~~~~~~~~~~^^
  File "D:/a/nicotine-plus/nicotine-plus/pynicotine/__init__.py", line 224, in run
    exit_code = application.run(ci_mode, isolated_mode)
  File "D:/a/nicotine-plus/nicotine-plus/pynicotine/ttktui/__init__.py", line 29, in run
    error = check_ttk_version()
  File "D:/a/nicotine-plus/nicotine-plus/pynicotine/ttktui/__init__.py", line 11, in check_ttk_version
    from TermTk import __version__ as TTk_version
  File "D:/a/nicotine-plus/nicotine-plus/pynicotine/external/pyTermTk/TermTk/__init__.py", line 25, in <module>
    from .TTkTheme       import *
  File "D:/a/nicotine-plus/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkTheme/__init__.py", line 1, in <module>
    from .theme import *
  File "D:/a/nicotine-plus/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkTheme/theme.py", line 25, in <module>
    from TermTk.TTkCore.color import TTkColor
  File "D:/a/nicotine-plus/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkCore/__init__.py", line 8, in <module>
    from .ttk      import *
  File "D:/a/nicotine-plus/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkCore/ttk.py", line 47, in <module>
    from TermTk.TTkWidgets.about import TTkAbout
  File "D:/a/nicotine-plus/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkWidgets/__init__.py", line 16, in <module>
    from .combobox        import *
  File "D:/a/nicotine-plus/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkWidgets/combobox.py", line 38, in <module>
    from TermTk.TTkWidgets.list_ import TTkList
  File "D:/a/nicotine-plus/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkWidgets/list_.py", line 32, in <module>
    class TTkList(TTkAbstractScrollArea):
    ...<321 lines>...
            return self._listView.setCurrentItem(item=item)
  File "D:/a/nicotine-plus/nicotine-plus/pynicotine/external/pyTermTk/TermTk/TTkWidgets/list_.py", line 33, in TTkList
    __doc__ = '''
              ~~~
    :py:class:`TTkList` is a container widget which place :py:class:`TTkListWidget` in a scrolling area with on-demand scroll bars.
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    
    
    ''' + TTkListWidget.__doc__
    ~~~~^~~~~~~~~~~~~~~~~~~~~~~
TypeError: can only concatenate str (not "NoneType") to str
```