### PR TITLE
fix(signal): clear all slot refs

### DIFF
--- a/libs/pyTermTk/TermTk/TTkCore/signal.py
+++ b/libs/pyTermTk/TermTk/TTkCore/signal.py
@@ -177,6 +177,8 @@ class pyTTkSignal():
         for slot in args:
             if slot in self._connected_slots:
                 del self._connected_slots[slot]
+            if slot in self._connected_async_slots:
+                del self._connected_async_slots[slot]
 
     def emit(self, *args, **kwargs) -> None:
         if not self._mutex.acquire(False): return
@@ -191,12 +193,14 @@ class pyTTkSignal():
         self._mutex.release()
 
     def clear(self):
-        self._connected_slots = {}
+        self._connected_slots.clear()
+        self._connected_async_slots.clear()
 
     @staticmethod
     def clearAll():
         for s in pyTTkSignal._signals:
             s.clear()
+        pyTTkSignal._signals.clear()
 
     def forward(self):
         def _ret(*args, **kwargs) -> None:


### PR DESCRIPTION
- Added: Remove async slots on `clear()` or `disconnect()` as well as normal callables
- Changed: Use Python `clear()` to actually remove items from the slots dictionary instead of creating another one with `{}`
- Added: Also clear `_signals` from the list with `clearAll()` after removing all their slots

This makes it more likely that old reference cycles will be properly broken so that disconnected slots can be garbage collected, because the number of dictionaries left dangling with leaking slot references still in them is greatly reduced.