### PR TITLE
chore(menubar): cleanup unused shortcutColor style

### DIFF
--- a/libs/pyTermTk/TermTk/TTkCore/string.py
+++ b/libs/pyTermTk/TermTk/TTkCore/string.py
@@ -63,6 +63,7 @@ class TTkString():
         # Combination of constructors (Highly Unrecommended)
         str7 = TTkString("test 7", color=TTkColor.fg('#FF0000'))
     '''
+    mnemonicColor = TTkColor.fg("#dddddd") + TTkColor.UNDERLINE
     unicodeWideOverflowColor = TTkColor.fg("#888888")+TTkColor.bg("#000088")
 
     __slots__ = ('_text','_colors','_baseColor','_hasTab','_hasSpecialWidth')
@@ -551,7 +552,7 @@ class TTkString():
             if _found:
                 _found = False
                 _ret.append(ch)
-                color += TTkColor.UNDERLINE
+                color += self.mnemonicColor  # UNDERLINE
             _newText += ch
             _newColors.append(color)
         return TTkString._importString1(_newText,_newColors), _ret

--- a/libs/pyTermTk/TermTk/TTkWidgets/menubar.py
+++ b/libs/pyTermTk/TermTk/TTkWidgets/menubar.py
@@ -36,20 +36,19 @@ from TermTk.TTkWidgets.menu import TTkMenuButton
 class TTkMenuBarButton(TTkMenuButton):
     classStyle = TTkMenuButton.classStyle | {
                 'default': TTkMenuButton.classStyle['default'] |
-                           {'borderColor':TTkColor.RST, 'shortcutColor': TTkColor.fg("#dddddd") + TTkColor.UNDERLINE,
+                           {'borderColor':TTkColor.RST,
                             'glyphs':('├','─','┤','┄','┄','▶')},
                 'clicked': TTkMenuButton.classStyle['clicked'] |
                            {'color': TTkColor.fg("#ffff88")},
             }
 
-    __slots__=('_shortcut')
+    __slots__ = ()
     def __init__(self, *,
                  text:TTkString=...,
                  data:object=None,
                  checkable:bool=False,
                  checked:bool=False,
                  **kwargs) -> None:
-        self._shortcut = []
         super().__init__(text=text, data=data, checkable=checkable, checked=checked, **kwargs)
         self.setCheckable(self.isCheckable())
 
@@ -70,7 +69,7 @@ class TTkMenuBarButton(TTkMenuButton):
         borderColor = style['borderColor']
         glyphs      = style['glyphs']
         textColor   = style['color']
-        scColor     = style['shortcutColor']
+
         if self._checkable:
             text = ('▣ ' if self._checked else '□ ') + self.text()
         else:
@@ -80,8 +79,6 @@ class TTkMenuBarButton(TTkMenuButton):
         canvas.drawText(pos=(1+text.termWidth(),0), color=borderColor ,text=glyphs[0])
         canvas.drawText(pos=(1,0), color=textColor ,text=text)
 
-        for sc in self._shortcut:
-            canvas.drawChar(pos=(0,sc+1), char=text.charAt(sc), color=scColor)
 
 class TTkMenuBarLayout(TTkHBoxLayout):
     '''TTkMenuBarLayout'''
@@ -101,9 +98,9 @@ class TTkMenuBarLayout(TTkHBoxLayout):
     def addMenu(self,text:TTkString, data:object=None, checkable:bool=False, checked:bool=False, alignment=TTkK.LEFT_ALIGN):
         '''addMenu'''
         text = text if issubclass(type(text),TTkString) else TTkString(text)
-        text, shortcuts = text.extractShortcuts()
+        text, mnemonics = text.extractShortcuts()  # TTkString.mnemonicColor
         button = TTkMenuBarButton(text=text, data=data, checkable=checkable, checked=checked)
-        for ch in shortcuts:
+        for ch in mnemonics:
             shortcut = TTkShortcut(key=TTkK.CTRL | ord(ch.upper()))
             shortcut.activated.connect(button.shortcutEvent)
         self._mbItems(alignment).addWidget(button)


### PR DESCRIPTION
Code cleanup only, as the removed style code was previously unreachable. No functional change except the underlined mnemonic also has a specific foreground color.

- Removed: Orphan `shortcutColor` style and `_shortcut` attribute that were unimplemented in _TTkMenuBarButton()_
- Added: Implement `mnemonicColor` for `TTkColor.UNDERLINE` in _TTkString()_

Ideally other widgets (such as regular buttons and overlay context menus that are not part of a menubar) would also have mnemonics processed, so we should consider moving the code that connects the `activated` signal to somewhere else.