### PR TITLE
fix: add pygments to tlogg's dependencies

### DIFF
--- a/apps/tlogg/pyproject.toml
+++ b/apps/tlogg/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
     'pyTermTk>=0.50.0-a0',
     'appdirs',
     'copykitten',
-    'pyyaml'
+    'pyyaml',
+    'pygments'
 ]
 
 [project.urls]


### PR DESCRIPTION
It appears `tlogg` requires `pygments` to work, but it's not declared in the project file.