### PR TITLE
fix(color): cleanup equality operator

### DIFF
--- a/libs/pyTermTk/TermTk/TTkCore/canvas.py
+++ b/libs/pyTermTk/TermTk/TTkCore/canvas.py
@@ -653,12 +653,12 @@ class TTkCanvas():
         slice_off = slice(xoffset,wslice)
         if canvas._transparent:
             for iy in range(yoffset,hslice):
-                if None in canvas._data[iy][slice_off]:
+                if any(data is None for data in canvas._data[iy][slice_off]):
                     self._data[y+iy][slice_ab]   = [cca if cca is not None else ccb for cca,ccb in zip(canvas._data[iy][slice_off],self._data[y+iy][slice_ab])]
                 else:
                     self._data[y+iy][slice_ab]   = canvas._data[iy][slice_off]
-                if None in canvas._colors[iy][slice_off]:
-                    self._colors[y+iy][slice_ab] = [cca if cca else ccb for cca,ccb in zip(canvas._colors[iy][slice_off],self._colors[y+iy][slice_ab])]
+                if any(color is None for color in canvas._colors[iy][slice_off]):
+                    self._colors[y+iy][slice_ab] = [cca if cca is not None else ccb for cca,ccb in zip(canvas._colors[iy][slice_off],self._colors[y+iy][slice_ab])]
                 else:
                     self._colors[y+iy][slice_ab] = canvas._colors[iy][slice_off]
         else:

--- a/libs/pyTermTk/TermTk/TTkCore/color.py
+++ b/libs/pyTermTk/TermTk/TTkCore/color.py
@@ -534,7 +534,6 @@ class TTkColor:
         return self._buffer
 
     def __eq__(self, other) -> bool:
-        if not  isinstance(other, TTkColor): return False
         return (
             self._fg   == other._fg and
             self._bg   == other._bg )

--- a/libs/pyTermTk/TermTk/TTkCore/string.py
+++ b/libs/pyTermTk/TermTk/TTkCore/string.py
@@ -448,7 +448,7 @@ class TTkString():
         out   = ""
         color = None
         for ch, col in zip(self._text, self._colors):
-            if col != color:
+            if color is None or col != color:
                 color = col
                 out += str(TTkColor.RST) + str(color)
             out += ch

--- a/libs/pyTermTk/TermTk/TTkWidgets/scrollbar.py
+++ b/libs/pyTermTk/TermTk/TTkWidgets/scrollbar.py
@@ -259,19 +259,3 @@ class TTkScrollBar(TTkWidget):
         self._value = v
         self.valueChanged.emit(v)
         self.update()
-
-    def color(self):
-        return self._color
-
-    def setColor(self, color):
-        if self._color != color:
-            self._color = color
-            self.update()
-
-    def focusColor(self):
-        return self._focusColor
-
-    def setFocusColor(self, color):
-        if self._focusColor != color:
-            self._focusColor = color
-            self.update()


### PR DESCRIPTION
Fixed performance regression of the buffer painting since #638 ...

- Removed: `isinstance()` call in `__eq__()`... This is used for `==`, `!=` and `in` operators so it is too expensive to use here.
- Changed: Check `if any(colors is None...)` which avoids doing equality tests of the values `in` list in `paintCanvas()`.
- Removed: Old methods in `scrollbar` which always raised `AttributeError` since only `classStyle` is used there.
 
The changes in this PR are the only instances I can find in the codebase where the `other` argument could have been `None`. As such, the slow checking of the `other` type with `isinstance()` shall no longer be required any more.

If there are other callers which call this equality operator with something other than a `TTkColor` object, then that calling code ought to be caught and fixed instead of silently catching wrong types here.