### PR TITLE
feat(canvas): new buffer check color data identity

### DIFF
--- a/libs/pyTermTk/TermTk/TTkCore/canvas.py
+++ b/libs/pyTermTk/TermTk/TTkCore/canvas.py
@@ -767,7 +767,7 @@ class TTkCanvas():
             count = 0
             chBk = ''
             for x,(da,db,ca,cb) in enumerate(zip(lda,ldb,lca,lcb)):
-                if da==db and ca==cb:
+                if da is db and ca is cb:
                     if not empty:
                         ansi += "" if not chBk else chBk*count if count<=4 else f"{chBk}\033[{count-1}b"
                         TTkTerm.push(ansi)
@@ -782,7 +782,7 @@ class TTkCanvas():
                     empty = False
                     count = 0
                     chBk = ''
-                if color != lastcolor:
+                if color is not lastcolor:
                     ansi += ("" if not chBk else chBk*count if count<=4 else f"{chBk}\033[{count-1}b") + str(color-lastcolor)
                     lastcolor = color
                     count = 0


### PR DESCRIPTION
- Changed: Optimization by using `==` to `is` in the new buffer push method. Only applicable if `doubleBufferNew=True`.

The `is` check is a raw pointer comparison with no module method call, no tuple unpacking, and no attribute access. It eliminates all calls to `TTkColor.__eq__()` in the hottest loop in the library, in favor of simply checking if the data and colors are the same objects or not.

There doesn't seem to be many or any cases where the objects are different but have the same values, so this optimization doesn't appear to result in extra bytes being written to the terminal unnecessarily.

This is much faster than performing separate equality comparison operations for both the foreground and background color values for each character being pushed in the paint event, especially since it avoids the very slow `isinstance()` call in the `__eq__()` method of color.py which was recently added in PR #638 (but even if that regression is fixed by PR #641 , then this would still be a good optimization to make anyway).