### PR TITLE
fix(propertyanimation): resolve postponed annotations before casting

### DIFF
--- a/libs/pyTermTk/TermTk/TTkCore/propertyanimation.py
+++ b/libs/pyTermTk/TermTk/TTkCore/propertyanimation.py
@@ -25,6 +25,7 @@ __all__ = ['TTkPropertyAnimation', 'TTkEasingCurve']
 import time, math
 from inspect import getfullargspec
 from types import LambdaType
+from typing import get_type_hints
 
 from TermTk.TTkCore.log import TTkLog
 from TermTk.TTkCore.signal import pyTTkSignal, pyTTkSlot
@@ -328,8 +329,15 @@ class TTkPropertyAnimation():
                 _args = _spec.args
             else:
                 _args = _spec.args[1:] if hasattr(self._cb, '__self__') else _spec.args
+            # "from __future__ import annotations" (PEP 563) keeps the annotations
+            # as strings, those must be resolved before being used as a cast.
+            try:
+                _annotations = get_type_hints(self._cb)
+            except Exception:
+                _annotations = _spec.annotations
+            _annotations = {_a:_t for _a,_t in _annotations.items() if callable(_t)}
             _castList = [
-                (lambda x:_spec.annotations[a](x)) if a in _spec.annotations else (lambda x:x) for a in _args]
+                (lambda x,_t=_annotations[a]:_t(x)) if a in _annotations else (lambda x:x) for a in _args]
             def _ret(*args):
                 return [c(x) for (c,x) in zip(_castList, args)]
             return _ret

--- a/tests/pytest/test_009_property_animation.py
+++ b/tests/pytest/test_009_property_animation.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2026 Eugenio Parodi <ceccopierangiolieugenio AT googlemail DOT com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import sys, os
+
+sys.path.append(os.path.join(sys.path[0],'../../libs/pyTermTk'))
+
+import TermTk as ttk
+
+def test_cast_bound_method_postponed_annotations():
+    # TTkWidget.move(x:int, y:int) lives in a module using
+    # "from __future__ import annotations", so its annotations are strings.
+    widget = ttk.TTkWidget()
+    anim = ttk.TTkPropertyAnimation(None, widget.move)
+    assert anim._cast(1.6, 2.4) == [1, 2]
+
+def test_cast_property_name_postponed_annotations():
+    widget = ttk.TTkWidget()
+    anim = ttk.TTkPropertyAnimation(widget, 'move')
+    assert anim._cast(1.6, 2.4) == [1, 2]
+
+def test_cast_lambda_is_not_casted():
+    anim = ttk.TTkPropertyAnimation(None, lambda x: x)
+    assert anim._cast(3.7) == [3.7]


### PR DESCRIPTION
Closes #493

`TTkPropertyAnimation` builds its cast list from `getfullargspec().annotations`. In modules using `from __future__ import annotations` (PEP 563) those annotations are plain strings, so the cast called a `str` and raised `TypeError: 'str' object is not callable`. `TTkWidget` is such a module, which is why `TTkPropertyAnimation(None, winTe.move)` crashed in `demo/showcase/animation.01.py`.

Annotations are now resolved with `typing.get_type_hints()` (falling back to the raw spec annotations) and non-callable entries are skipped.

Added `tests/pytest/test_009_property_animation.py`: the two postponed-annotation cases fail with the reported `TypeError` without the fix and pass with it; the full `tests/pytest` suite is green (1071 passed).
